### PR TITLE
Fix handling of ansible version numbers

### DIFF
--- a/streisand
+++ b/streisand
@@ -4,7 +4,7 @@ echo
 echo -e "\033[38;5;255m\033[48;5;234m\033[1m  S T R E I S A N D  \033[0m"
 echo
 
-if [[ "$(ansible --version | grep -oe '1.[0-9].[0-9]')" < "1.6" ]]
+if [[ "$(ansible --version | grep -oe '1\(.\d\)*')" < "1.6" ]]
 then
     echo "Ansible version 1.6+ is required."
     exit -1;


### PR DESCRIPTION
Presently, the Ansible version check fails for version numbers like `1.7`. Update the version check such that `1.7` is considered > `1.6`.
