### PR TITLE
Readme deb/ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,6 @@ Installation
   * On OS X (via [Homebrew](http://brew.sh/))
 
             brew install git
-* Install [Ansible](http://www.ansible.com/home). If you have an existing installation note that Ansible version 1.6+ is required.
-  * On OS X (via [Homebrew](http://brew.sh/))
-
-            brew install ansible 
-
-
 * Install the [pip](https://pip.pypa.io/en/latest/) package management system for Python.
   * On Debian and Ubuntu (also installs the dependencies that are necessary to build Ansible)
 


### PR DESCRIPTION
By default Debian/Ubuntu doesn't install git (7.x & 14.04) so you need to install it before you can do a git clone of streisand. Great project by the way, just getting started with it!
