### PR TITLE
update ansible_python_interpreter

### DIFF
--- a/inventory
+++ b/inventory
@@ -1,5 +1,5 @@
 [localhost]
-127.0.0.1
+127.0.0.1 ansible_python_interpreter=python
 
 # Uncomment the following lines and update the IP address if you would
 # like to use Streisand to configure a server that is already running


### PR DESCRIPTION
This resolves [issue 12](https://github.com/jlund/streisand/issues/12). Since Ansible uses a fixed Python path, this change ensures that the Python interpreter generated by Virtualenv is used instead. Given the case that Virtualenv is not being used, it will fallback to whichever Python interpreter is first on the user's $PATH. 
