### PR TITLE
Server Provisioning Cleanup

### DIFF
--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -25,19 +25,20 @@
     - name: "aws_region_var"
       prompt: >
         What region should the server be located in?
-          1. Asia Pacific (Tokyo)
-          2. Asia Pacific (Singapore)
-          3. Asia Pacific (Sydney)
-          4. EU (Ireland)
-          5. South America (Sao Paulo)
-          6. US East (Northern Virginia)
-          7. US West (Northern California)
-          8. US West (Oregon)
+          1. Asia Pacific     (Tokyo)
+          2. Asia Pacific     (Singapore)
+          3. Asia Pacific     (Sydney)
+          4. EU               (Ireland)
+          5. South America    (Sao Paulo)
+          6. US East          (Northern Virginia)
+          7. US West          (Northern California)
+          8. US West          (Oregon)
+        Please choose the number of your region. Press enter for default (#2) region.
       default: "2"
       private: no
 
     - name: "aws_instance_name_var"
-      prompt: "\nWhat should the server be named?\n"
+      prompt: "\nWhat should the server be named? Press enter for default (streisand).\n"
       default: "streisand"
       private: no
 
@@ -50,7 +51,7 @@
       private: no
 
     - name: "confirmation"
-      prompt: "\nStreisand will now set up your server. This process usually takes around ten minutes. Press Enter to continue...\n"
+      prompt: "\nStreisand will now set up your server. This process usually takes around ten minutes. Press Enter to begin setup...\n"
 
   # Facts persist across plays, and these facts will be used in the
   # final step to make an API call to open all of the necessary ports in

--- a/playbooks/digitalocean.yml
+++ b/playbooks/digitalocean.yml
@@ -18,19 +18,20 @@
   vars_prompt:
     - name: "do_region"
       prompt: >
-        Enter the number of the region where the server will be located:
-          1. Amsterdam (one)
-          2. Amsterdam (two)
+        What region should the server be located in?
+          1. Amsterdam        (Datacenter 1)
+          2. Amsterdam        (Datacenter 2)
           3. London
-          4. New York (one)
-          5. New York (two)
+          4. New York         (Datacenter 1)
+          5. New York         (Datacenter 2)
           6. San Francisco
           7. Singapore
+        Please choose the number of your region. Press enter for default (#2) region.
       default: "2"
       private: no
 
     - name: "do_server_name"
-      prompt: "\nWhat should the server be named?\n"
+      prompt: "\nWhat should the server be named? Press enter for default (streisand).\n"
       default: "streisand"
       private: no
 
@@ -43,7 +44,7 @@
       private: no
 
     - name: "confirmation"
-      prompt: "\nStreisand will now set up your server. This process usually takes around ten minutes. Press Enter to continue...\n"
+      prompt: "\nStreisand will now set up your server. This process usually takes around ten minutes. Press Enter to begin setup...\n"
 
   roles:
     - genesis-digitalocean

--- a/playbooks/linode.yml
+++ b/playbooks/linode.yml
@@ -17,18 +17,19 @@
   vars_prompt:
     - name: "linode_datacenter"
       prompt: >
-        Enter the number of the region where the server will be located:
+        What region should the server be located in?
           1. Atlanta
           2. Dallas
           3. Fremont
           4. London
           5. Newark
           6. Tokyo
+        Please choose the number of your region. Press enter for default (#6) region.
       default: "6"
       private: no
 
     - name: "linode_server_name"
-      prompt: "\nWhat should the server be named?\n"
+      prompt: "\nWhat should the server be named? Press enter for default (streisand).\n"
       default: "streisand"
       private: no
 
@@ -37,7 +38,7 @@
       private: no
 
     - name: "confirmation"
-      prompt: "\nStreisand will now set up your server. This process usually takes around ten minutes. Press Enter to continue...\n"
+      prompt: "\nStreisand will now set up your server. This process usually takes around ten minutes. Press Enter to begin setup...\n"
 
   roles:
     - genesis-linode

--- a/playbooks/rackspace.yml
+++ b/playbooks/rackspace.yml
@@ -22,11 +22,12 @@
           3. Hong Kong
           4. Northern Virginia
           5. Sydney
+        Please choose the number of your region. Press enter for default (#3) region.
       default: "3"
       private: no
 
     - name: "rackspace_server_name"
-      prompt: "\nWhat should the server be named?\n"
+      prompt: "\nWhat should the server be named? Press enter for default (streisand).\n"
       private: no
       default: "streisand"
 
@@ -39,7 +40,7 @@
       private: no
 
     - name: "confirmation"
-      prompt: "\nStreisand will now set up your server. This process usually takes around ten minutes. Press Enter to continue...\n"
+      prompt: "\nStreisand will now set up your server. This process usually takes around ten minutes. Press Enter to begin setup...\n"
 
   roles:
     - genesis-rackspace


### PR DESCRIPTION
I did some minor cleanup and standardized the prompts in the server provisioning yml files at streisand/playbooks/[host].yml. The prompts were slightly changed to inform users of the default values, and for server providers that have multiple datacenters in a geographical regions, I used tabs to make it look better.
