### PR TITLE
Fix SSH connectivity detection

### DIFF
--- a/playbooks/roles/genesis-digitalocean/tasks/main.yml
+++ b/playbooks/roles/genesis-digitalocean/tasks/main.yml
@@ -27,7 +27,7 @@
   register: streisand_server
 
 - name: Wait until the server has finished booting and OpenSSH is accepting connections
-  shell: curl --silent --max-time 5 {{ streisand_server.droplet.ip_address }}:22 | grep 'SSH'
+  shell: echo quit | telnet {{ streisand_server.droplet.ip_address }} 22 2>/dev/null | grep Connected
   register: connection_attempt
   until: connection_attempt | success
   retries: 20


### PR DESCRIPTION
Currently, streisand fails to detect if the server is up or not when doing an install for DigitalOcean. The reason is server returning an empty response, thus failing the connectivity check.

This PR replaces it with something more reliable.
