### PR TITLE
Update to Tor Browser Bundle 3.6.5

### DIFF
--- a/playbooks/roles/streisand-mirror/vars/tor.yml
+++ b/playbooks/roles/streisand-mirror/vars/tor.yml
@@ -7,7 +7,7 @@ tor_mirror_href_base: "/mirror/tor"
 tor_erinn_clark_key_id: "0x416F061063FEE659"
 tor_erinn_clark_expected_fingerprint: "Key fingerprint = 8738 A680 B84B 3031 A630  F2DB 416F 0610 63FE E659"
 
-tor_browser_bundle_version: "3.6.4"
+tor_browser_bundle_version: "3.6.5"
 tor_base_download_url: "https://www.torproject.org/dist/torbrowser"
 
 # Windows


### PR DESCRIPTION
Otherwise install fails after receiving 404 form every mirror
