### PR TITLE
updated stunnel and tor mirror versions

### DIFF
--- a/playbooks/roles/streisand-mirror/vars/stunnel.yml
+++ b/playbooks/roles/streisand-mirror/vars/stunnel.yml
@@ -7,7 +7,7 @@ stunnel_mirror_href_base: "/mirror/stunnel"
 stunnel_michal_trojnara_key_id: "0xFCD53E9D74C732D1"
 stunnel_michal_trojnara_expected_fingerprint: "Key fingerprint = F6B1 BFC5 5F32 243F B2C8  919A FCD5 3E9D 74C7 32D1"
 
-stunnel_version: "5.03"
+stunnel_version: "5.04"
 stunnel_base_download_url: "http://www.stunnel.org/downloads"
 
 stunnel_installer_filename: "stunnel-{{ stunnel_version }}-installer.exe"

--- a/playbooks/roles/streisand-mirror/vars/tor.yml
+++ b/playbooks/roles/streisand-mirror/vars/tor.yml
@@ -7,7 +7,7 @@ tor_mirror_href_base: "/mirror/tor"
 tor_erinn_clark_key_id: "0x416F061063FEE659"
 tor_erinn_clark_expected_fingerprint: "Key fingerprint = 8738 A680 B84B 3031 A630  F2DB 416F 0610 63FE E659"
 
-tor_browser_bundle_version: "3.6.5"
+tor_browser_bundle_version: "3.6.6"
 tor_base_download_url: "https://www.torproject.org/dist/torbrowser"
 
 # Windows


### PR DESCRIPTION
Right now the mirror fails because the versions specified no longer exist. 
