### PR TITLE
Proof of concept Docker run based install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:2.7.12
+RUN pip install ansible markupsafe boto dopy==0.3.5 apache-libcloud>=0.17.0 linode-python pyrax
+COPY . /usr/src/streisand
+WORKDIR /usr/src/streisand
+CMD /usr/src/streisand/streisand

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ In some circumstances advanced users may opt to use the local provisioning mode 
 ### Prerequisites ###
 Complete all of these tasks on your local home machine.
 
+* If you have a working Docker install available, you can skip this section and [continue below](#docker-execution).
 * Streisand requires a BSD, Linux, or OS X system. As of now, Windows is not supported. All of the following commands should be run inside a Terminal session.
 * Python 2.7 is required. This comes standard on OS X, and is the default on almost all Linux and BSD distributions as well. If your distribution packages Python 3 instead, you will need to install version 2.7 in order for Streisand to work properly.
 * Make sure an SSH key is present in ~/.ssh/id\_rsa.pub.
@@ -171,6 +172,15 @@ Complete all of these tasks on your local home machine.
 3. Follow the prompts to choose your provider, the physical region for the server, and its name. You will also be asked to enter API information.
 4. Once login information and API keys are entered, Streisand will begin spinning up a new remote server.
 5. Wait for the setup to complete (this usually takes around ten minutes) and look for the corresponding files in the 'generated-docs' folder in the Streisand repository directory. The HTML file will explain how to connect to the Gateway over SSL, or via the Tor hidden service. All instructions, files, mirrored clients, and keys for the new server can then be found on the Gateway. You are all done!
+
+<a name="docker-execution"></a>
+### Docker Execution ###
+1. Execute the Streisand script from Docker hub (if you prefer you can build the Dockerfile in the repository root locally).
+
+        docker run -it --rm jlund/streisand
+2. Follow the prompts to choose your provider, the physical region for the server, and its name. You will also be asked to enter API information.
+3. Once login information and API keys are entered, Streisand will begin spinning up a new remote server.
+4. Wait for the setup to complete (this usually takes around ten minutes) and look for the corresponding files in the 'generated-docs' folder in the Streisand repository directory. The HTML file will explain how to connect to the Gateway over SSL, or via the Tor hidden service. All instructions, files, mirrored clients, and keys for the new server can then be found on the Gateway. You are all done!
 
 ### Running Streisand to Provision Localhost (Advanced) ###
 


### PR DESCRIPTION
I saw some issues discussing using Docker for hosting the Streisand services, but I didn't see any suggesting it for encapsulating the installer automation.

This abstracts away some of the complexities of managing OS and pip installed packages, especially around versions/paths. Obviously, it does replace these with a requirement for a working Docker install, but I suspect many technical people would have that already. This PR adds that, although I have not yet really tested it (happy to help with this if the overall idea is considered useful) - particularly handling of SSH keys and other state would need to be added.

The instructions assume that this would be added as an automated build on Docker hub - this would mean that the build automatically updates if you push a change to the pip install line specifying a specific version of something. Since that doesn't actually exist yet, you can build locally by running (in the git root of this branch):
```
docker build -t streisand .
docker run -it --rm streisand
```

Note that there is an existing Docker image at https://hub.docker.com/r/gdoteof/streisand-launcher/ - I think there is some advantage in having an "official" image however, both in terms of trust and manageability (ability to specify library versions etc).

Some other things for discussion:

- This is starting from the official python 2.7.12 image. However, we could start from pretty much anywhere - we could also pick a "2.7" version to get automatic bug-fixes. We could also use the alpine or slim variant for a faster download, although there is a higher chance we would need to install some extra packages (curl etc).
- Rather than include separate "docker" instructions we could instead just note that you can skip prerequisites (except git) if you have Docker installed and then add the docker run command to the streisand script if Docker is detected.