### PR TITLE
Update to Ansible 2.4 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo apt-get install python-pip python-dev ca-certificates shellcheck -qq
 
 install:
-  - pip install ansible==2.3.0.0
+  - pip install ansible==2.4.0.0
   - pip install urllib3 yamllint
   - ansible --version
 

--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -109,7 +109,7 @@
   roles:
     - genesis-amazon
 
-- include: ssh-setup.yml
-- include: cloud-status.yml
-- include: streisand.yml
+- import_playbook: ssh-setup.yml
+- import_playbook: cloud-status.yml
+- import_playbook: streisand.yml
 ...

--- a/playbooks/azure.yml
+++ b/playbooks/azure.yml
@@ -131,7 +131,7 @@
   roles:
     - genesis-azure
 
-- include: ssh-setup.yml
-- include: cloud-status.yml
-- include: streisand.yml
+- import_playbook: ssh-setup.yml
+- import_playbook: cloud-status.yml
+- import_playbook: streisand.yml
 ...

--- a/playbooks/digitalocean.yml
+++ b/playbooks/digitalocean.yml
@@ -60,7 +60,7 @@
   roles:
     - genesis-digitalocean
 
-- include: ssh-setup.yml
-- include: cloud-status.yml
-- include: streisand.yml
+- import_playbook: ssh-setup.yml
+- import_playbook: cloud-status.yml
+- import_playbook: streisand.yml
 ...

--- a/playbooks/existing-server.yml
+++ b/playbooks/existing-server.yml
@@ -28,10 +28,10 @@
             msg: "Unable to SSH to existing streisand-host.\nEnsure private key corresponding to \"{{ streisand_ssh_key }}\" is loaded in your SSH key agent.\nTry using `ssh-keygen -i {{ streisand_ssh_key }} to generate your key if it does not exist\n"
 
 # Ensure Python is installed on the system
-- include: python.yml
+- import_playbook: python.yml
 
 # Try and detect the remote server's provider & apply required workarounds
-- include: provider-detect.yml
+- import_playbook: provider-detect.yml
 
 - name: Prepare the remote server for Streisand
 # =========================================
@@ -39,5 +39,5 @@
   remote_user: "{{ lookup('env', 'SSH_USER') }}"
   become: true
 
-- include: streisand.yml
+- import_playbook: streisand.yml
 ...

--- a/playbooks/google.yml
+++ b/playbooks/google.yml
@@ -127,7 +127,7 @@
   roles:
     - genesis-google
 
-- include: ssh-setup.yml
-- include: cloud-status.yml
-- include: streisand.yml
+- import_playbook: ssh-setup.yml
+- import_playbook: cloud-status.yml
+- import_playbook: streisand.yml
 ...

--- a/playbooks/linode.yml
+++ b/playbooks/linode.yml
@@ -49,6 +49,6 @@
   roles:
     - genesis-linode
 
-- include: ssh-setup.yml
-- include: streisand.yml
+- import_playbook: ssh-setup.yml
+- import_playbook: streisand.yml
 ...

--- a/playbooks/localhost.yml
+++ b/playbooks/localhost.yml
@@ -3,10 +3,10 @@
 # role to create a new server and instead applies Streisand to the localhost.
 
 # Ensure Python is installed on the system
-- include: python.yml
+- import_playbook: python.yml
 
 # Try and detect localhost's provider & apply required workarounds
-- include: provider-detect.yml
+- import_playbook: provider-detect.yml
 
 - name: Prepare the localhost for Streisand
 # =========================================
@@ -30,5 +30,5 @@
         streisand_ipv4_address: "{{ ansible_default_ipv4.address }}"
       when: streisand_ipv4_address is not defined
 
-- include: streisand.yml
+- import_playbook: streisand.yml
 ...

--- a/playbooks/rackspace.yml
+++ b/playbooks/rackspace.yml
@@ -45,7 +45,7 @@
   roles:
     - genesis-rackspace
 
-- include: ssh-setup.yml
-- include: cloud-status.yml
-- include: streisand.yml
+- import_playbook: ssh-setup.yml
+- import_playbook: cloud-status.yml
+- import_playbook: streisand.yml
 ...

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -5,7 +5,7 @@
   when: ansible_distribution != "Ubuntu" or ansible_distribution_version != "16.04"
 
 # Set default variables
-- include: set-default-variables.yml
+- import_tasks: set-default-variables.yml
 
 - name: Ensure the APT cache is up to date
   apt:

--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -143,7 +143,7 @@
     creates: /etc/ipsec.d/cert8.db
 
 # Ensure l2tp firewall rules are in place
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 - name: Enable and start ipsec and l2tp services
   systemd:
@@ -156,4 +156,4 @@
     - xl2tpd
 
 # Generate l2tp instructions and mobile profiles
-- include: docs.yml
+- import_tasks: docs.yml

--- a/playbooks/roles/lets-encrypt/tasks/main.yml
+++ b/playbooks/roles/lets-encrypt/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: install.yml
+- import_tasks: install.yml
 
 - name: Prepare response file directory
   file:
@@ -20,7 +20,7 @@
 # requests (including ACME chanllenges). All HTTP requests are simply
 # redirected to their HTTPS counterparts.
 
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 # Now we try to request a certificate. If it fails. We print a warning and
 # fall back to self-signed certificates.

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Download, compile and install ocserv and its dependencies
-- include: install.yml
+- import_tasks: install.yml
 
 - name: Create the ocserv configuration directory
   file:
@@ -166,10 +166,10 @@
   notify: Restart ocserv
 
 # Set up the openconnect firewall rules
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 # Generate Gateway documentation
-- include: docs.yml
+- import_tasks: docs.yml
 
 # Mirror the OpenConnect clients
-- include: mirror.yml
+- import_tasks: mirror.yml

--- a/playbooks/roles/openvpn/tasks/main.yml
+++ b/playbooks/roles/openvpn/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Add the apt key and install OpenVPN
-- include: install.yml
+- import_tasks: install.yml
 
 - name: "Configure DNSMasq to listen on {{ dnsmasq_openvpn_tcp_ip }}:53 and {{ dnsmasq_openvpn_udp_ip }}:53"
   template:
@@ -236,13 +236,13 @@
     label: "{{ item[0].item }}"
 
 # Set up the OpenVPN firewall rules
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 # Generate Gateway documentation
-- include: docs.yml
+- import_tasks: docs.yml
 
 # Mirror the OpenVPN clients
-- include: mirror.yml
+- import_tasks: mirror.yml
 
 # Install stunnel
 # NOTE (@alimakki) - must be done after OpenVPN's Gateway task

--- a/playbooks/roles/shadowsocks/tasks/main.yml
+++ b/playbooks/roles/shadowsocks/tasks/main.yml
@@ -94,7 +94,7 @@
   changed_when: False
 
 # Add simple-obfs task file
-- include: simple-obfs.yml
+- import_tasks: simple-obfs.yml
 
 - name: Generate Shadowsocks config file
   template:
@@ -132,10 +132,10 @@
         timeout: 30
 
 # Apply the Shadowsocks firewall rules
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 # Generate the Shadowsocks gateway docs & client QR code
-- include: docs.yml
+- import_tasks: docs.yml
 
 # Mirror the Shadowsocks clients
-- include: mirror.yml
+- import_tasks: mirror.yml

--- a/playbooks/roles/ssh-forward/tasks/main.yml
+++ b/playbooks/roles/ssh-forward/tasks/main.yml
@@ -20,7 +20,7 @@
     key: 'command="{{ ssh_force_command }}" {{ ssh_forward_key.stdout }}'
 
 # Generate the gateway documentation for the SSH forward user
-- include: docs.yml
+- import_tasks: docs.yml
 
 # Mirror Putty for SSH forwarding from Windows
-- include: mirror.yml
+- import_tasks: mirror.yml

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Use OpenSSL to generate self-signed certificates if we do not have Let's Encrypt.
-- include: openssl.yml
+- import_tasks: openssl.yml
   when: not le_ok
 
 # Include Let's Encrypt variables for template rendering

--- a/playbooks/roles/stunnel/tasks/main.yml
+++ b/playbooks/roles/stunnel/tasks/main.yml
@@ -43,7 +43,7 @@
     dest: "{{ openvpn_gateway_location }}/stunnel.conf"
 
 # Set up the stunnel firewall rules
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 # Mirror the stunnel client
-- include: mirror.yml
+- import_tasks: mirror.yml

--- a/playbooks/roles/test-client/tasks/main.yml
+++ b/playbooks/roles/test-client/tasks/main.yml
@@ -135,7 +135,7 @@
   with_items: "{{ test_scripts }}"
 
 # Run the WireGuard tests
-- include: wireguard.yml
+- import_tasks: wireguard.yml
   tags:
     - wireguard
 ...

--- a/playbooks/roles/test-client/tasks/wireguard.yml
+++ b/playbooks/roles/test-client/tasks/wireguard.yml
@@ -1,7 +1,7 @@
 ---
 
 # Install the WireGuard PPA and packages
-- include: "../../wireguard/tasks/install.yml"
+- import_tasks: "../../wireguard/tasks/install.yml"
 
 - name: "Download the WireGuard wg0-client config file"
   get_url:

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -24,7 +24,7 @@
 # NOTE(@cpu): we do this early in the role because the Tor daemon will check if
 # the obfs4proxy port is externally accessible during startup and we want to
 # make sure it is.
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 - name: Generate a random Nickname for the bridge
   shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ //' | cut -c 1-16 > {{ tor_bridge_nickname_file }}
@@ -124,7 +124,7 @@
   changed_when: False
 
 # Generate the docs gateway page
-- include: docs.yml
+- import_tasks: docs.yml
 
 # Mirror the Tor browser bundle
-- include: mirror.yml
+- import_tasks: mirror.yml

--- a/playbooks/roles/tor-bridge/tasks/mirror.yml
+++ b/playbooks/roles/tor-bridge/tasks/mirror.yml
@@ -4,15 +4,15 @@
 
 - block:
     # Include the mirror-common tasks
-    - include: mirror-common.yml
+    - import_tasks: mirror-common.yml
 
-    - include: mirror-download.yml
+    - include_tasks: mirror-download.yml
       with_items: "{{ streisand_languages.values() | map(attribute='tor_locale') | list }}"
       when: locale in tor_available_locales
       loop_control:
         loop_var: locale
 
-    - include: mirror-verify.yml
+    - import_tasks: mirror-verify.yml
   rescue:
     - name: "{{ streisand_mirror_warning }}"
       pause:

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # Set up the PPA and install packages
-- include: install.yml
+- import_tasks: install.yml
 
 - name: Generate private and public keys for the client and server
   shell: umask 077; wg genkey | tee {{ item.private }} | wg pubkey > {{ item.public }}
@@ -40,7 +40,7 @@
     - wg0-server.conf
 
 # Set up the WireGuard firewall rules
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 - name: Enable the WireGuard service so it starts at boot, and bring up the WireGuard network interface
   systemd:
@@ -57,4 +57,4 @@
   notify: Restart dnsmasq
 
 # Generate Gateway documentation
-- include: docs.yml
+- import_tasks: docs.yml

--- a/playbooks/streisand.yml
+++ b/playbooks/streisand.yml
@@ -1,6 +1,6 @@
 ---
-- include: python.yml
-- include: lets-encrypt.yml
+- import_playbook: python.yml
+- import_playbook: lets-encrypt.yml
 
 - name: Collect diagnostics in case of error
   hosts: localhost

--- a/playbooks/vagrant.yml
+++ b/playbooks/vagrant.yml
@@ -1,5 +1,5 @@
 ---
-- include: python.yml
+- import_playbook: python.yml
 
 - name: Prepare the vagrant VM for Ansible
 # =========================================
@@ -21,6 +21,6 @@
   roles:
     - validation
 
-- include: ssh-setup.yml
-- include: streisand.yml
+- import_playbook: ssh-setup.yml
+- import_playbook: streisand.yml
 ...

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 nocows = 1
-roles_path = ../playbooks/roles/
+roles_path = playbooks/roles/
 host_key_checking = False
 remote_tmp = $HOME/.ansible/tmp
 local_tmp = $HOME/.ansible/tmp

--- a/tests/run.yml
+++ b/tests/run.yml
@@ -63,4 +63,4 @@
         streisand_server_name: "{{ server_name | regex_replace('\\s', '_') }}"
 
 - name: Include streisand.yml
-  include: ../playbooks/streisand.yml
+  import_playbook: ../playbooks/streisand.yml

--- a/tests/syntax-check.yml
+++ b/tests/syntax-check.yml
@@ -1,34 +1,34 @@
 ---
 #Include each playbook in order to check syntax of each playbook
 - name: Include amazon.yml
-  include: ../playbooks/amazon.yml
+  import_playbook: ../playbooks/amazon.yml
 
 - name: Include azure.yml
-  include: ../playbooks/streisand.yml
+  import_playbook: ../playbooks/streisand.yml
 
 - name: Include cloud-status.yml
-  include: ../playbooks/cloud-status.yml
+  import_playbook: ../playbooks/cloud-status.yml
 
 - name: Include digitalocean.yml
-  include: ../playbooks/digitalocean.yml
+  import_playbook: ../playbooks/digitalocean.yml
 
 - name: Include google.yml
-  include: ../playbooks/google.yml
+  import_playbook: ../playbooks/google.yml
 
 - name: Include linode.yml
-  include: ../playbooks/linode.yml
+  import_playbook: ../playbooks/linode.yml
 
 - name: Include rackspace.yml
-  include: ../playbooks/rackspace.yml
+  import_playbook: ../playbooks/rackspace.yml
 
 - name: Include streisand.yml
-  include: ../playbooks/streisand.yml
+  import_playbook: ../playbooks/streisand.yml
 
 - name: Include run.yml
-  include: run.yml
+  import_playbook: run.yml
 
 - name: Include development-setup.yml
-  include: development-setup.yml
+  import_playbook: development-setup.yml
 
 #Explicity include each role to ensure all roles are tested
 - hosts: localhost

--- a/util/ansible_check.sh
+++ b/util/ansible_check.sh
@@ -6,7 +6,7 @@ set -e
 # check_ansible checks that Ansible is installed on the local system
 # and that it is a supported version.
 function check_ansible() {
-  local REQUIRED_ANSIBLE_VERSION="2.3.0"
+  local REQUIRED_ANSIBLE_VERSION="2.4.0"
 
   if ! command -v ansible > /dev/null 2>&1; then
     echo "


### PR DESCRIPTION
This patch updates `include` syntax to `import_tasks` `include_tasks` `import_playbook`, and raises the required version of Ansible to 2.4.

I have tested this on a fresh EC2 instance, all went well.

Ref: https://github.com/StreisandEffect/streisand/issues/994