### PR TITLE
POC: Replace id_rsa with just id_rsa.pub and a working ssh-agent

### DIFF
--- a/global_vars/default-site.yml
+++ b/global_vars/default-site.yml
@@ -7,7 +7,7 @@
 # The SSH private key that Ansible will use to connect to the Streisand node.
 # The associated public key will be used if required when provisioning cloud
 # nodes for the authorized_keys file.
-streisand_ssh_private_key: "~/.ssh/id-rsa"
+streisand_ssh_public_key: "~/.ssh/id_rsa.pub"
 
 vpn_clients: 5
 

--- a/playbooks/customize.yml
+++ b/playbooks/customize.yml
@@ -4,9 +4,9 @@
   gather_facts: no
 
   vars_prompt:
-    - name: streisand_ssh_private_key
-      prompt: "Enter the path to your SSH private key, or press enter for default "
-      default: "~/.ssh/id_rsa"
+    - name: streisand_ssh_public_key
+      prompt: "Enter the path to your SSH public key, or press enter for default "
+      default: "~/.ssh/id_rsa.pub"
       private: no
     - name: vpn_clients
       prompt: "How many VPN client profiles should be generated per-service? Press enter for default "

--- a/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
+++ b/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
@@ -48,7 +48,7 @@ It will help the developers reproduce your problem and provide a fix.
 * Streisand Git revision: {{ streisand_diagnostics_git_rev.stdout }}
 * Streisand Git clone has untracked changes: {{ streisand_diagnostics_git_untracked.stdout }}
 * Genesis role: {{ streisand_genesis_role | default("None") }}
-* Custom SSH key: {{ streisand_ssh_private_key != "~/.ssh/id_rsa" }}
+* Custom SSH key: {{ streisand_ssh_public_key != "~/.ssh/id_rsa" }}
 
 ### Enabled Roles
 

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -2,8 +2,8 @@
 - set_fact:
     streisand_genesis_role: "genesis-amazon"
 
-- name: "Get the {{ streisand_ssh_private_key }}.pub contents"
-  command: "cat {{ streisand_ssh_private_key }}.pub"
+- name: "Get the {{ streisand_ssh_public_key }} contents"
+  command: "cat {{ streisand_ssh_public_key }}"
   register: ssh_key
   changed_when: False
 

--- a/playbooks/roles/genesis-azure/tasks/main.yml
+++ b/playbooks/roles/genesis-azure/tasks/main.yml
@@ -2,8 +2,8 @@
 - set_fact:
     streisand_genesis_role: "genesis-azure"
 
-- name: "Get the {{ streisand_ssh_private_key }}.pub contents"
-  command: "cat {{ streisand_ssh_private_key }}.pub"
+- name: "Get the {{ streisand_ssh_public_key }} contents"
+  command: "cat {{ streisand_ssh_public_key }}"
   register: ssh_key
   changed_when: False
 

--- a/playbooks/roles/genesis-digitalocean/tasks/main.yml
+++ b/playbooks/roles/genesis-digitalocean/tasks/main.yml
@@ -2,8 +2,8 @@
 - set_fact:
     streisand_genesis_role: "genesis-digitalocean"
 
-- name: "Get the {{ streisand_ssh_private_key }}.pub contents"
-  command: "cat {{ streisand_ssh_private_key }}.pub"
+- name: "Get the {{ streisand_ssh_public_key }} contents"
+  command: "cat {{ streisand_ssh_public_key }}"
   register: ssh_key
   changed_when: False
 

--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -2,8 +2,8 @@
 - set_fact:
     streisand_genesis_role: "genesis-google"
 
-- name: "Get the {{ streisand_ssh_private_key }}.pub contents"
-  command: "cat {{ streisand_ssh_private_key }}.pub"
+- name: "Get the {{ streisand_ssh_public_key }} contents"
+  command: "cat {{ streisand_ssh_public_key }}"
   register: ssh_key
   changed_when: False
 

--- a/playbooks/roles/genesis-linode/tasks/main.yml
+++ b/playbooks/roles/genesis-linode/tasks/main.yml
@@ -2,8 +2,8 @@
 - set_fact:
     streisand_genesis_role: "genesis-linode"
 
-- name: "Get the {{ streisand_ssh_private_key }}.pub contents"
-  command: "cat {{ streisand_ssh_private_key }}.pub"
+- name: "Get the {{ streisand_ssh_public_key }} contents"
+  command: "cat {{ streisand_ssh_public_key }}"
   register: ssh_key
   changed_when: False
 

--- a/playbooks/roles/genesis-rackspace/tasks/main.yml
+++ b/playbooks/roles/genesis-rackspace/tasks/main.yml
@@ -2,8 +2,8 @@
 - set_fact:
     streisand_genesis_role: "genesis-rackspace"
 
-- name: "Get the {{ streisand_ssh_private_key }}.pub contents"
-  command: "cat {{ streisand_ssh_private_key }}.pub"
+- name: "Get the {{ streisand_ssh_public_key }} contents"
+  command: "cat {{ streisand_ssh_public_key }}"
   register: ssh_key
   changed_when: False
 

--- a/playbooks/roles/validation/tasks/ssh.yml
+++ b/playbooks/roles/validation/tasks/ssh.yml
@@ -1,28 +1,19 @@
 ---
 - block:
-    - name: "Stat the Streisand SSH private key"
+    - name: "Stat the Streisand SSH public key, {{ streisand_ssh_public_key }}"
       stat:
-        path: "{{ streisand_ssh_private_key }}"
-      register: streisand_ssh_private_key_status
-      changed_when: False
-    - name: "Fail if the Streisand SSH private key file doesn't exist"
-      fail:
-        msg: "The Streisand SSH private key \"{{ streisand_ssh_private_key }}\" does not exist."
-      when: streisand_ssh_private_key_status.stat.exists == False
-    - name: "Stat the Streisand SSH public key"
-      stat:
-        path: "{{ streisand_ssh_private_key }}.pub"
+        path: "{{ streisand_ssh_public_key }}"
       register: streisand_ssh_key_status
       changed_when: False
     - name: "Fail if the Streisand SSH public key file doesn't exist"
       fail:
-        msg: "The Streisand SSH public key \"{{ streisand_ssh_private_key }}.pub\" does not exist."
+        msg: "The Streisand SSH public key \"{{ streisand_ssh_public_key }}\" does not exist."
       when: streisand_ssh_key_status.stat.exists == False
-      #- name: "Register the Streisand SSH public key"
-      #command: "cat {{ streisand_ssh_private_key }}.pub"
-      #register: streisand_ssh_key
-      #changed_when: False
+    - name: "Register the Streisand SSH public key"
+      command: "cat {{ streisand_ssh_public_key }}"
+      register: streisand_ssh_key
+      changed_when: False
 
   rescue:
     - fail:
-        msg: "Ensure you specified an existing SSH private key file (not public).\n Try using `ssh-keygen -f {{ streisand_ssh_private_key }} to generate your key if it does not exist\n"
+        msg: "XXX nop Ensure you specified an existing SSH public key file.\n Try using `ssh-keygen -f {{ streisand_ssh_public_key }} to generate your key if it does not exist\n"

--- a/playbooks/ssh-setup.yml
+++ b/playbooks/ssh-setup.yml
@@ -4,4 +4,4 @@
   gather_facts: no
   tasks:
     - set_fact:
-        ansible_ssh_private_key_file: "{{ streisand_ssh_private_key }}"
+        not_really_the_ansible_ssh_private_key_file: "{{ streisand_ssh_public_key }}"

--- a/tests/run.yml
+++ b/tests/run.yml
@@ -7,9 +7,9 @@
   pre_tasks:
     - name: Ensure python is installed
       raw: sudo apt update && apt install python -y
-  tasks:
-    - set_fact:
-        ansible_ssh_private_key_file: "{{ streisand_ssh_private_key }}"
+  #tasks:
+  #  - set_fact:
+  #      not_really_ansible_ssh_private_key_file: "{{ streisand_ssh_public_key }}"
 
 - hosts: streisand
   gather_facts: yes


### PR DESCRIPTION
(Another one of those "don't merge this" specials, to document where I am.)

We don't need the private key for anything; what we need is the
capability of logging in. Depend on a working `ssh-agent` that can
unlock `~/id_rsa.pub`.

This PR is not user-friendly now. It requires people who don't
understand ssh to understand `ssh-agent` too. It could be made more
friendly for the old case of an existing `id_rsa`/`id_rsa.pub` by:

1. forcing an `ssh-agent` inside of streisand

2. running `ssh-add` early on, so we can bomb if the user can't unlock
the key.

This is what I do in the Docker builder.

This commit breaks CI, and I don't know how to fix it yet.