### PR TITLE
Refactor OpenSSL CA/Server/Client certificate generation into its own role

### DIFF
--- a/documentation/certificates.md
+++ b/documentation/certificates.md
@@ -1,0 +1,91 @@
+Streisand PKI
+=============
+
+Streisand includes a role responsible for PKI certificate generation,
+separated into two distinct tasks:
+
+ - CA/Server
+ - Client(s)
+
+The first of which will generate a certificate authority, and a server 
+certificate signed by the newly minted certificate authority.
+
+The latter task is responsible for generating client side certificate
+(using the same CA) used for authenticting connecting VPN clients.
+
+Each VPN service that leverages PKI generates its own CA/Server and 
+client certificates.
+
+Infrastructure
+--------------
+
+The overall PKI infrasture assumes the following layout:
+
+```
+Web Root CA: 
+   \__ gateway HTTPS cert (unless LE; see below)
+
+OpenConnect CA: 
+   \__ OpenConnect server cert
+   \__ OpenConnect client 1
+   \__ OpenConnect client ...
+   \__ OpenConnect client n
+
+OpenVPN CA: 
+   \__ OpenVPN server cert
+   \__ OpenVPN client 1
+   \__ OpenVPN client ...
+   \__ OpenVPN client n
+
+IPsec-IKEv2 CA (upcoming):
+   \__ IPsec-IKEv2 server cert
+   \__ foobar client 1
+   \__ foobar client ...
+   \__ foobar client n
+
+ISRG X1:
+   \__ Let's Encrypt Authority X3
+        \__ poem-walk.example.com HTTPS cert
+``` 
+
+Usage
+-----
+
+Utilizing the `certificates` role can be invoked as follows (using OpenVPN as an example):
+(Should client certificates need to be generated, they should be done so priort to invocation)
+
+```
+- name: Create directories for clients
+  file:
+    path: "/etc/openvpn/{{ client_name.stdout }}"
+    state: directory
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
+- include_role:
+    name: certificates
+  vars:
+    ca_path:            "/etc/openvpn"
+    tls_ca:             "/etc/openvpn/ca"
+    tls_client_path:    "/etc/openvpn"
+    generate_ca_server: yes
+    generate_client:    yes
+    tls_request_subject:         "/C=US/ST=California/L=Beverly Hills/O=ACME CORPORATION/OU=Anvil Department"
+    tls_server_common_name_file: "/etc/openvpn/openvpn-common-name.txt"
+    tls_sans:                    # sets the Subject Alternative Name(s) attribute(s)
+      - "1.2.3.4"
+      - "5.6.7.8"
+```
+
+Note the following flags:
+ - `generate_ca_server: yes`
+ - `generate_client: yes`
+
+ These must be made explicit, as the default value is `no`; certificates should not be generated unless
+ they have to be.
+
+The certificates role makes certain assumptions with regards to default values,
+all of which can be inspected [here](https://github.com/StreisandEffect/streisand/blob/master/playbooks/roles/certificates/defaults/main.yml).
+

--- a/documentation/certificates.md
+++ b/documentation/certificates.md
@@ -7,23 +7,23 @@ separated into two distinct tasks:
  - CA/Server
  - Client(s)
 
-The first of which will generate a certificate authority, and a server 
+The first will generate a certificate authority, and a server 
 certificate signed by the newly minted certificate authority.
 
-The latter task is responsible for generating client side certificate
-(using the same CA) used for authenticting connecting VPN clients.
+The latter task is responsible for generating client side certificates
+(using the same CA) used for authenticating connecting VPN clients.
 
-Each VPN service that leverages PKI generates its own CA/Server and 
-client certificates.
+Each VPN service that leverages the Streisand PKI generates its
+own CA/Server certificate and client certificates.
 
 Infrastructure
 --------------
 
-The overall PKI infrasture assumes the following layout:
+The overall PKI infrastructure assumes the following structure:
 
 ```
 Web Root CA: 
-   \__ gateway HTTPS cert (unless LE; see below)
+   \__ gateway HTTPS cert (unless Let's Encrypt; see below)
 
 OpenConnect CA: 
    \__ OpenConnect server cert
@@ -37,25 +37,20 @@ OpenVPN CA:
    \__ OpenVPN client ...
    \__ OpenVPN client n
 
-IPsec-IKEv2 CA (upcoming):
-   \__ IPsec-IKEv2 server cert
-   \__ foobar client 1
-   \__ foobar client ...
-   \__ foobar client n
-
 ISRG X1:
    \__ Let's Encrypt Authority X3
-        \__ poem-walk.example.com HTTPS cert
+        \__ streisand.example.com HTTPS cert
 ``` 
 
 Usage
 -----
 
 Utilizing the `certificates` role can be invoked as follows (using OpenVPN as an example):
-(Should client certificates need to be generated, they should be done so priort to invocation)
+(If client certificates need to be generated, a directory for each client must be created
+first)
 
 ```
-- name: Create directories for clients
+- name: Create directories for clients # needed if client certificates are required
   file:
     path: "/etc/openvpn/{{ client_name.stdout }}"
     state: directory

--- a/playbooks/roles/certificates/defaults/main.yml
+++ b/playbooks/roles/certificates/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+tls_key_country:  "US"
+tls_key_province: "California"
+tls_key_city:     "Beverly Hills"
+tls_key_org:      "ACME CORPORATION"
+tls_key_ou:       "Anvil Department"
+tls_days_valid:   "1825"
+tls_default_md:   "sha256"
+tls_key_size:     "4096"

--- a/playbooks/roles/certificates/defaults/main.yml
+++ b/playbooks/roles/certificates/defaults/main.yml
@@ -7,3 +7,8 @@ tls_key_ou:       "Anvil Department"
 tls_days_valid:   "1825"
 tls_default_md:   "sha256"
 tls_key_size:     "4096"
+
+# What type of certificates to be generated
+# must be explicitly set
+generate_ca_server: no
+generate_client:    no

--- a/playbooks/roles/certificates/defaults/main.yml
+++ b/playbooks/roles/certificates/defaults/main.yml
@@ -9,6 +9,7 @@ tls_default_md:   "sha256"
 tls_key_size:     "4096"
 
 # What type of certificates to be generated
-# must be explicitly set
+# must be explicitly set by playbooks that
+# include the certificates role
 generate_ca_server: no
 generate_client:    no

--- a/playbooks/roles/certificates/tasks/ca-server.yml
+++ b/playbooks/roles/certificates/tasks/ca-server.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Generate RSA keys for the CA and Server"
+- name: "Generate the private keys for the CA and Server certificates"
   command: openssl genrsa -out {{ item }}.key {{ tls_key_size }}
   args:
     chdir: "{{ ca_path }}"
@@ -8,7 +8,7 @@
     - ca
     - server
 
-- name: Set the proper permissions on all RSA keys
+- name: Set the proper permissions on all the private keys
   file:
     path: "{{ ca_path }}"
     recurse: yes
@@ -18,7 +18,7 @@
     mode: 0600
 
 - name: Generate CA certificate
-  command: openssl req -nodes -batch -new -x509 -key {{ tls_ca }}.key -out {{ tls_ca }}.crt -days {{ tls_days_valid }} -subj "{{ tls_request_subject }}/CN=ca-certificate"
+  command: openssl req -nodes -batch -new -x509 -key {{ tls_ca }}.key -out {{ tls_ca }}.crt -subj "{{ tls_request_subject }}/CN=ca-certificate"
   args:
     creates: "{{ tls_ca }}.crt"
 
@@ -39,7 +39,7 @@
   register: tls_server_common_name
   changed_when: False
 
-- name: Generate the OpenSSL configuration that will be used for the Server certificate's req and ca commands
+- name: Generate the OpenSSL configuration that will be used for the server certificate's req and ca commands
   template:
     src: openssl.cnf.j2
     dest: "{{ ca_path }}/openssl.cnf"

--- a/playbooks/roles/certificates/tasks/ca-server.yml
+++ b/playbooks/roles/certificates/tasks/ca-server.yml
@@ -1,0 +1,67 @@
+---
+- name: "Generate RSA keys for the CA and Server"
+  command: openssl genrsa -out {{ item }}.key {{ tls_key_size }}
+  args:
+    chdir: "{{ ca_path }}"
+    creates: "{{ item }}.key"
+  with_items:
+    - ca
+    - server
+
+- name: Set the proper permissions on all RSA keys
+  file:
+    path: "{{ ca_path }}"
+    recurse: yes
+    state: directory
+    owner: root
+    group: root
+    mode: 0600
+
+- name: Generate CA certificate
+  command: openssl req -nodes -batch -new -x509 -key {{ tls_ca }}.key -out {{ tls_ca }}.crt -days {{ tls_days_valid }} -subj "{{ tls_request_subject }}/CN=ca-certificate"
+  args:
+    creates: "{{ tls_ca }}.crt"
+
+- name: Generate a random server common name
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /./g' | cut -c 1-64 > {{ tls_server_common_name_file }}
+  args:
+    creates: "{{ tls_server_common_name_file }}"
+
+- name: Set permissions on the TLS server common name file
+  file:
+    path: "{{ tls_server_common_name_file }}"
+    owner: root
+    group: root
+    mode: 0600
+
+- name: Register the TLS server common name
+  command: cat "{{ tls_server_common_name_file }}"
+  register: tls_server_common_name
+  changed_when: False
+
+- name: Generate the OpenSSL configuration that will be used for the Server certificate's req and ca commands
+  template:
+    src: openssl.cnf.j2
+    dest: "{{ ca_path }}/openssl.cnf"
+
+- name: Seed a blank database file that will be used when generating the Server's certificate
+  file:
+    path: "{{ ca_path }}/index.txt"
+    state: touch
+
+- name: Seed a serial file that will be used when generating the Server's certificate
+  copy:
+    content: "01"
+    dest: "{{ ca_path }}/serial"
+
+- name: Generate CSR for the Server
+  command: openssl req -batch -extensions server -new -key server.key -out server.csr -config {{ ca_path }}/openssl.cnf
+  args:
+    chdir: "{{ ca_path }}"
+    creates: server.csr
+
+- name: Generate certificate for the Server
+  command: openssl ca -batch -extensions server -in server.csr -out server.crt -config openssl.cnf
+  args:
+    chdir: "{{ ca_path }}"
+    creates: server.crt

--- a/playbooks/roles/certificates/tasks/client.yml
+++ b/playbooks/roles/certificates/tasks/client.yml
@@ -1,5 +1,5 @@
 ---
-- name: Generate RSA keys for the clients
+- name: Generate the private keys for the client certificates
   command: openssl genrsa -out client.key {{ tls_key_size }}
   args:
     chdir: "{{ tls_client_path }}/{{ client_name.stdout }}"
@@ -9,7 +9,7 @@
     loop_var: "client_name"
     label: "{{ client_name.item }}"
 
-- name: Set the proper permissions on all RSA keys
+- name: Set the proper permissions on all private client keys
   file:
     path: "{{ ca_path }}"
     recurse: yes

--- a/playbooks/roles/certificates/tasks/client.yml
+++ b/playbooks/roles/certificates/tasks/client.yml
@@ -1,0 +1,39 @@
+---
+- name: Generate RSA keys for the clients
+  command: openssl genrsa -out client.key {{ tls_key_size }}
+  args:
+    chdir: "{{ tls_client_path }}/{{ client_name.stdout }}"
+    creates: client.key
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
+- name: Set the proper permissions on all RSA keys
+  file:
+    path: "{{ ca_path }}"
+    recurse: yes
+    state: directory
+    owner: root
+    group: root
+    mode: 0600
+
+- name: Generate CSRs for the clients
+  command: openssl req -new -extensions client -key client.key -out client.csr -subj "{{ tls_request_subject }}/CN={{ client_name.stdout }}" -config {{ ca_path }}/openssl.cnf
+  args:
+    chdir: "{{ tls_client_path }}/{{ client_name.stdout }}"
+    creates: client.csr
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
+- name: Generate certificates for the clients
+  command: openssl x509 -extensions client -CA {{ tls_ca }}.crt -CAkey {{ tls_ca }}.key -CAcreateserial -req -days {{ tls_days_valid }} -in client.csr -out client.crt -extfile {{ ca_path }}/openssl.cnf
+  args:
+    chdir: "{{ tls_client_path }}/{{ client_name.stdout }}"
+    creates: client.crt
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"

--- a/playbooks/roles/certificates/tasks/main.yml
+++ b/playbooks/roles/certificates/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- include: ca-server.yml
+  when: generate_ca_server
+
+- include: client.yml
+  when: generate_client

--- a/playbooks/roles/certificates/tasks/main.yml
+++ b/playbooks/roles/certificates/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: ca-server.yml
+- import_tasks: ca-server.yml
   when: generate_ca_server
 
-- include: client.yml
+- import_tasks: client.yml
   when: generate_client

--- a/playbooks/roles/certificates/templates/openssl.cnf.j2
+++ b/playbooks/roles/certificates/templates/openssl.cnf.j2
@@ -3,23 +3,25 @@ default_ca = CA_default
 
 [ CA_default ]
 
-dir = {{ openvpn_path }}
+dir = {{ ca_path }}
 certs = $dir
 crl_dir = $dir
 database = $dir/index.txt
 new_certs_dir = $dir
 
-certificate = {{ openvpn_ca }}.crt
+certificate = {{ tls_ca }}.crt
 serial = $dir/serial
 crl = $dir/crl.pem
-private_key = {{ openvpn_ca }}.key
+private_key = {{ tls_ca }}.key
 RANDFILE = $dir/.rand
+
+copy_extensions = copy
 
 x509_extensions = server
 
-default_days = {{ openvpn_days_valid }}
+default_days = {{ tls_days_valid }}
 default_crl_days= 30
-default_md = sha256
+default_md = {{ tls_default_md }}
 preserve = no
 
 policy = policy_anything
@@ -28,7 +30,6 @@ keyUsage = cRLSign, keyCertSign
 
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always,issuer:always
-
 
 [ policy_anything ]
 countryName = optional
@@ -42,25 +43,37 @@ emailAddress = optional
 
 [ req ]
 distinguished_name = req_distinguished_name
+req_extensions     = req_ext
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+{% for item in tls_san %}
+IP.{{ loop.index }} = {{ item }}
+{% endfor %}
 
 [ req_distinguished_name ]
 countryName = Country Name (2 letter code)
-countryName_default = {{ openvpn_key_country }}
+countryName_default = {{ tls_key_country }}
 
 stateOrProvinceName = State or Province Name (full name)
-stateOrProvinceName_default = {{ openvpn_key_province }}
+stateOrProvinceName_default = {{ tls_key_province }}
 
 localityName = Locality Name (eg, city)
-localityName_default = {{ openvpn_key_city }}
+localityName_default = {{ tls_key_city }}
 
 0.organizationName = Organization Name (eg, company)
-0.organizationName_default = {{ openvpn_key_org }}
+0.organizationName_default = {{ tls_key_org }}
 
 organizationalUnitName = Organizational Unit Name (eg, section)
-organizationalUnitName_default = {{ openvpn_key_ou }}
+organizationalUnitName_default = {{ tls_key_ou }}
 
 commonName = Common Name (eg, your name or your server\'s hostname)
-commonName_default = {{ openvpn_server_common_name.stdout }}
+commonName_default = {{ tls_server_common_name.stdout }}
+
+[ v3_ca ]
+keyUsage = digitalSignature, keyEncipherment
 
 [ server ]
 basicConstraints=CA:FALSE
@@ -69,6 +82,7 @@ subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
 extendedKeyUsage=serverAuth
 keyUsage = digitalSignature, keyEncipherment
+subjectAltName = @alt_names
 
 [ client ]
 basicConstraints=CA:FALSE

--- a/playbooks/roles/certificates/templates/openssl.cnf.j2
+++ b/playbooks/roles/certificates/templates/openssl.cnf.j2
@@ -49,7 +49,7 @@ req_extensions     = req_ext
 subjectAltName = @alt_names
 
 [ alt_names ]
-{% for item in tls_san %}
+{% for item in tls_sans %}
 IP.{{ loop.index }} = {{ item }}
 {% endfor %}
 

--- a/playbooks/roles/certificates/vars/main.yml
+++ b/playbooks/roles/certificates/vars/main.yml
@@ -1,0 +1,2 @@
+---
+tls_request_subject: "/C={{ tls_key_country }}/ST={{ tls_key_province }}/L={{ tls_key_city }}/O={{ tls_key_org }}/OU={{ tls_key_ou }}"

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -32,7 +32,7 @@
     loop_var: "client_name"
     label: "{{ client_name.item }}"
 
-- import_playbook:
+- include_role:
     name: certificates
   vars:
     ca_path:            "{{ ocserv_path }}"

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -32,7 +32,7 @@
     loop_var: "client_name"
     label: "{{ client_name.item }}"
 
-- include_role:
+- import_playbook:
     name: certificates
   vars:
     ca_path:            "{{ ocserv_path }}"
@@ -41,7 +41,7 @@
     generate_ca_server: yes
     generate_client:    yes
     tls_server_common_name_file: "{{ ocserv_server_common_name_file }}"
-    tls_san:
+    tls_sans:
       - "{{ streisand_ipv4_address }}"
 
 - name: "Generate a random password that will be used during the PKCS #12 conversion"

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -23,71 +23,26 @@
   args:
     creates: /etc/rc0.d/K20ocserv
 
-- name: Generate the CA template file
-  template:
-    src: ca.tmpl.j2
-    dest: "{{ ocserv_ca_template_file }}"
-    owner: root
-    group: root
-    mode: 0600
-
-- name: Generate the CA key
-  command: certtool --generate-privkey --outfile {{ ocserv_ca_key_file }}
-  args:
-    creates: "{{ ocserv_ca_key_file }}"
-
-- name: Generate the self-signed CA certificate
-  command: certtool --generate-self-signed --load-privkey {{ ocserv_ca_key_file }} --template {{ ocserv_ca_template_file }} --outfile {{ ocserv_ca_certificate_file }}
-  args:
-    creates: "{{ ocserv_ca_certificate_file }}"
-
-- name: Generate the server template file
-  template:
-    src: server.tmpl.j2
-    dest: "{{ ocserv_server_template_file }}"
-    owner: root
-    group: root
-    mode: 0600
-
-- name: Generate the server key
-  command: certtool --generate-privkey --outfile {{ ocserv_server_key_file }}
-  args:
-    creates: "{{ ocserv_server_key_file }}"
-
-- name: Generate the server certificate
-  command: certtool --generate-certificate --load-privkey {{ ocserv_server_key_file }} --load-ca-certificate {{ ocserv_ca_certificate_file }} --load-ca-privkey {{ ocserv_ca_key_file }} --template {{ ocserv_server_template_file }} --outfile {{ ocserv_server_certificate_file }}
-  args:
-    creates: "{{ ocserv_server_certificate_file }}"
-
-- name: Generate the client template file
-  template:
-    src: client.tmpl.j2
-    dest: "{{ ocserv_path }}/client-{{ client_name.stdout }}.tmpl"
-    owner: root
-    group: root
-    mode: 0600
+- name: Create directories for clients
+  file:
+    path: "{{ ocserv_path}}/{{ client_name.stdout }}"
+    state: directory
   with_items: "{{ vpn_client_names.results }}"
   loop_control:
     loop_var: "client_name"
     label: "{{ client_name.item }}"
 
-- name: Generate the client keys
-  command: certtool --generate-privkey --outfile {{ ocserv_path }}/{{ client_name.stdout }}-key.pem
-  args:
-    creates: "{{ ocserv_path }}/{{ client_name.stdout }}-key.pem"
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-
-- name: Generate the client certificates
-  command: certtool --generate-certificate --load-privkey {{ ocserv_path }}/{{ client_name.stdout }}-key.pem --load-ca-certificate {{ ocserv_ca_certificate_file }} --load-ca-privkey {{ ocserv_ca_key_file }} --template {{ ocserv_path }}/client-{{ client_name.stdout }}.tmpl --outfile {{ ocserv_path }}/{{ client_name.stdout }}-cert.pem
-  args:
-    creates: "{{ ocserv_path }}/{{ client_name.stdout }}-cert.pem"
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
+- include_role:
+    name: certificates
+  vars:
+    ca_path:            "{{ ocserv_path }}"
+    tls_ca:             "{{ ocserv_ca }}"
+    tls_client_path:    "{{ ocserv_path }}"
+    generate_ca_server: yes
+    generate_client:    yes
+    tls_server_common_name_file: "{{ ocserv_server_common_name_file }}"
+    tls_san:
+      - "{{ streisand_ipv4_address }}"
 
 - name: "Generate a random password that will be used during the PKCS #12 conversion"
   shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /-/g' > {{ ocserv_path }}/ocserv-{{ client_name.stdout }}-pkcs12-password
@@ -120,7 +75,7 @@
 
 - name: "Convert the keys and certificates into PKCS #12 format"
   expect:
-    command: certtool --to-p12 --load-privkey {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}-key.pem --pkcs-cipher 3des-pkcs12 --load-certificate {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}-cert.pem --outfile {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}.p12 --outder
+    command: certtool --to-p12 --load-privkey {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}/client.key --pkcs-cipher 3des-pkcs12 --load-certificate {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}/client.crt --outfile {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}.p12 --outder
     responses:
       "Enter a name for the key": "{{ ocserv_client_password.client_name.stdout }}"
       "Enter password":   "{{ ocserv_client_password.stdout }}"

--- a/playbooks/roles/openconnect/templates/ca.tmpl.j2
+++ b/playbooks/roles/openconnect/templates/ca.tmpl.j2
@@ -1,8 +1,0 @@
-cn = "{{ ocserv_ca_cn }}"
-organization = "{{ ocserv_ca_organization }}"
-serial = 1
-expiration_days = {{ ocserv_days_valid }}
-ca
-signing_key
-cert_signing_key
-crl_signing_key

--- a/playbooks/roles/openconnect/templates/client.tmpl.j2
+++ b/playbooks/roles/openconnect/templates/client.tmpl.j2
@@ -1,5 +1,0 @@
-cn = {{ client_name.stdout }}
-unit = "users"
-expiration_days = {{ ocserv_days_valid }}
-signing_key
-tls_www_client

--- a/playbooks/roles/openconnect/templates/instructions-fr.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions-fr.md.j2
@@ -62,7 +62,7 @@ Les certificats clients sont un mécanisme par lequel les clients peuvent s'auth
    `brew install openconnect`
 
    * Si l'installation de Homebrew n'est pas une option, vous pouvez également télécharger et compiler le [code source OpenConnect](/mirror/index-fr.html#openconnect).
-1. Téléchargez le fichier [ca.crt](/openconnect/ ca.crt) et un [fichier de certificat client](#clientcerts) dans la liste ci-dessus.
+1. Téléchargez le fichier [ca.crt](/openconnect/ca.crt) et un [fichier de certificat client](#clientcerts) dans la liste ci-dessus.
 1. Placez les fichiers téléchargés dans un dossier distinct (par exemple `{{ streisand_server_name }}-openconnect`), ouvrez votre terminal, et `cd` dans la directoire.
 1. Lancez OpenConnect:
 

--- a/playbooks/roles/openconnect/templates/instructions-fr.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions-fr.md.j2
@@ -18,7 +18,7 @@ OpenConnect est un serveur VPN extrêmement performant et léger qui offre une c
 Les certificats clients sont un mécanisme par lequel les clients peuvent s'authentifier de manière sécurisée avec un serveur.
 
 1. Votre serveur OpenConnect émet son propre __certificat serveur__. Ceci est utilisé par le logiciel du client de votre appareil (tel que AnyConnect pour iOS) afin de  s'identifier de manière sécurisée avec le serveur VPN. Téléchargez le certificat de ce serveur.
-   * [ca-cert.pem](/openconnect/ca-cert.pem)
+   * [ca.crt](/openconnect/ca.crt)
 1. Chaque appareil que vous souhaitez configurer nécessite un __certificat client__ en plus du certificat serveur ci-dessus. Un certificat client est utilisé pour identifier et authentifier de manière sécurisée votre appareil sur le serveur VPN. Deux appareils ne peuvent pas utiliser le même certificat de client et être connectés simultanément (un certificat de client pour chaque appareil). Chaque certificat client est protégé par une mot de passe, qui sera nécessaire pour le déverrouiller une fois que vous l'importez dans votre appareil.
 {% for client in ocserv_client_pkcs12_password_list.results %}
    * [{{ client.client_name.stdout }}.p12](/openconnect/{{ client.client_name.stdout }}.p12), mot de passe: `{{ client.stdout }}` 
@@ -62,11 +62,11 @@ Les certificats clients sont un mécanisme par lequel les clients peuvent s'auth
    `brew install openconnect`
 
    * Si l'installation de Homebrew n'est pas une option, vous pouvez également télécharger et compiler le [code source OpenConnect](/mirror/index-fr.html#openconnect).
-1. Téléchargez le fichier [ca-cert.pem](/openconnect/ ca-cert.pem) et un [fichier de certificat client](#clientcerts) dans la liste ci-dessus.
+1. Téléchargez le fichier [ca.crt](/openconnect/ ca.crt) et un [fichier de certificat client](#clientcerts) dans la liste ci-dessus.
 1. Placez les fichiers téléchargés dans un dossier distinct (par exemple `{{ streisand_server_name }}-openconnect`), ouvrez votre terminal, et `cd` dans la directoire.
 1. Lancez OpenConnect:
 
-   `sudo openconnect --cafile ca-cert.pem --certificate votre-certificat-client.p12 --key-password 'mot-de-passe-du-certificat' --pfs {{ streisand_ipv4_address }}:{{ ocserv_port }}`
+   `sudo openconnect --cafile ca.crt --certificate votre-certificat-client.p12 --key-password 'mot-de-passe-du-certificat' --pfs {{ streisand_ipv4_address }}:{{ ocserv_port }}`
 1. Vous devriez être prêt à partir! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
 <a name="linux"></a>
@@ -75,7 +75,7 @@ Les certificats clients sont un mécanisme par lequel les clients peuvent s'auth
 
    `sudo apt-get install network-manager-openconnect-gnome`
 1. Téléchargez le certificat serveur:
-   * [ca-cert.pem](/openconnect/ca-cert.pem)
+   * [ca.crt](/openconnect/ca.crt)
 1. Ouvrez votre *Paramètres du système*.
 1. Cliquez sur l'icône *Réseau*.
 1. Cliquez le bouton *+* dans le coin inférieur gauche de la fenêtre.
@@ -83,7 +83,7 @@ Les certificats clients sont un mécanisme par lequel les clients peuvent s'auth
 1. Sélectionnez *VPN compatible Cisco AnyConnect (openconnect)* et cliquez *Créer*.
 1. Saisissez `{{ streisand_server_name }}` pour le *Nom du connexion*.
 1. Saisissez `{{ streisand_ipv4_address }}:{{ ocserv_port }}` pour la *Gateway* (passerelle).
-1. Sélectionnez le fichier `ca-cert.pem` Que vous venez de télécharger pour *Certificat CA*.
+1. Sélectionnez le fichier `ca.crt` Que vous venez de télécharger pour *Certificat CA*.
 1. Cliquez *Enregisterer*.
 1. Sélectionnez le VPN dans le menu à gauche, et faites glisser l'interrupteur vers la position *ON*. Vous pouvez également activer/désactiver le VPN en cliquant sur l'icône WiFi/Réseau dans la barre de menu, défiler vers *Connexions VPN* et en cliquant sur son nom.
 1. Saisissez `streisand` pour le champ *Nom d'utilisateur* puis cliquez *Connexion*.

--- a/playbooks/roles/openconnect/templates/instructions.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions.md.j2
@@ -18,7 +18,7 @@ OpenConnect is an extremely high-performance and lightweight VPN server that als
 Client certificates are a mechanism by which clients can authenticate themselves securely with the server.
 
 1. Your OpenConnect server issues its own __server certificate__. This is used by your device's client software (such as AnyConnect for iOS) to securely identify the VPN server. Download this server's certificate.
-   * [ca-cert.pem](/openconnect/ca-cert.pem)
+   * [ca.crt](/openconnect/ca.crt)
 1. Each device you wish to configure needs a __client certificate__ in addition to the server certificate above. A client certificate is used to securely identify and authenticate your device to the VPN server. Two devices can't use the same client certifcate and be logged in at the same time (one client certificate per device). Each client certificate is protected by a password, which will be needed to unlock it once you import it into your device.
 {% for client in ocserv_client_pkcs12_password_list.results %}
    * [{{ client.client_name.stdout }}.p12](/openconnect/{{ client.client_name.stdout }}.p12), password: `{{ client.stdout }}` 
@@ -62,11 +62,11 @@ Client certificates are a mechanism by which clients can authenticate themselves
    `brew install openconnect`
 
    * If installing Homebrew is not an option, you can also download and compile the [OpenConnect source code](/mirror/#openconnect).
-1. Download the [server certificate](/openconnect/ca-cert.pem) file, and a [client certificate file](#clientcerts) from the list above.
+1. Download the [server certificate](/openconnect/ca.crt) file, and a [client certificate file](#clientcerts) from the list above.
 1. Place the downloaded server certificate and a selected client certificate into a separate folder (e.g. `{{ streisand_server_name }}-openconnect`), open your Terminal, and `cd` to that directory.
 1. Run OpenConnect:
 
-  `sudo openconnect --cafile ca-cert.pem --certificate your-client-certificate.p12 --key-password 'your-client-certificate-password' --pfs {{ streisand_ipv4_address }}:{{ ocserv_port }}`
+  `sudo openconnect --cafile ca.crt --certificate your-client-certificate.p12 --key-password 'your-client-certificate-password' --pfs {{ streisand_ipv4_address }}:{{ ocserv_port }}`
 1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 
@@ -77,7 +77,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 
    `sudo apt-get install network-manager-openconnect-gnome`
 1. Download the server certificate file:
-   * [ca-cert.pem](/openconnect/ca-cert.pem)
+   * [ca.crt](/openconnect/ca.crt)
 1. Open your *System Settings*.
 1. Click the *Network* icon.
 1. Click the *+* button in the lower-left of the window.
@@ -85,7 +85,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 1. Select *Cisco AnyConnect Compatible VPN (openconnect)* and click *Create*.
 1. Enter `{{ streisand_server_name }}` for the *Connection name*.
 1. Enter `{{ streisand_ipv4_address }}:{{ ocserv_port }}` for the *Gateway*.
-1. Select the `ca-cert.pem` file that you just downloaded for the *CA Certificate*.
+1. Select the `ca.crt` file that you just downloaded for the *CA Certificate*.
 1. Click *Save*.
 1. Select the VPN in the left-hand menu, and flip the switch to *ON*. You can also enable/disable the VPN by clicking on the WiFi/Network icon in the menu bar, scrolling to *VPN Connections*, and clicking on its name.
 1. Enter `streisand` for the *Username* and click *Login*.

--- a/playbooks/roles/openconnect/templates/server.tmpl.j2
+++ b/playbooks/roles/openconnect/templates/server.tmpl.j2
@@ -1,6 +1,0 @@
-cn = {{ streisand_ipv4_address }}
-organization = "{{ ocserv_server_organization }}"
-expiration_days = {{ ocserv_days_valid }}
-signing_key
-encryption_key
-tls_www_server

--- a/playbooks/roles/openconnect/vars/main.yml
+++ b/playbooks/roles/openconnect/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 ocserv_path: "/etc/ocserv"
+ocserv_ca: "{{ ocserv_path }}/ca"
 ocserv_config_file: "{{ ocserv_path }}/config"
 ocserv_firewall_rule: "iptables --wait {{ streisand_iptables_wait }} -t nat -A POSTROUTING -j MASQUERADE"
 
@@ -38,17 +39,16 @@ ocserv_sig_location:    "/usr/local/src/{{ ocserv_sig_filename }}"
 ocserv_pid_file:    "/var/run/ocserv.pid"
 ocserv_socket_file: "/var/run/ocserv-socket"
 
-ocserv_ca_certificate_file: "{{ ocserv_path }}/ca-cert.pem"
-ocserv_ca_key_file:         "{{ ocserv_path }}/ca-key.pem"
-ocserv_ca_template_file:    "{{ ocserv_path }}/ca.tmpl"
+ocserv_ca_certificate_file: "{{ ocserv_path }}/ca.crt"
+ocserv_ca_key_file:         "{{ ocserv_path }}/ca.key"
 
-ocserv_server_certificate_file: "{{ ocserv_path }}/server-cert.pem"
-ocserv_server_key_file:         "{{ ocserv_path }}/server-key.pem"
-ocserv_server_template_file:    "{{ ocserv_path }}/server.tmpl"
+ocserv_server_certificate_file: "{{ ocserv_path }}/server.crt"
+ocserv_server_key_file:         "{{ ocserv_path }}/server.key"
 
-ocserv_client_name:          "streisand-openconnect-{{ streisand_ipv4_address }}"
+ocserv_hashed_password_file:    "{{ ocserv_path }}/ocpasswd"
+ocserv_password_file:           "{{ ocserv_path }}/ocserv-password"
+ocserv_server_common_name_file: "{{ ocserv_path }}/ocserv_server_common_name"
 
-ocserv_hashed_password_file: "{{ ocserv_path }}/ocpasswd"
-ocserv_password_file:        "{{ ocserv_path }}/ocserv-password"
+ocserv_client_name: "streisand-openconnect-{{ streisand_ipv4_address }}"
 
-ocserv_gateway_location:     "{{ streisand_gateway_location }}/openconnect"
+ocserv_gateway_location: "{{ streisand_gateway_location }}/openconnect"

--- a/playbooks/roles/openvpn/tasks/main.yml
+++ b/playbooks/roles/openvpn/tasks/main.yml
@@ -17,7 +17,7 @@
     loop_var: "client_name"
     label: "{{ client_name.item }}"
 
-- import_playbook:
+- include_role:
     name: certificates
   vars:
     ca_path:            "{{ openvpn_path }}"

--- a/playbooks/roles/openvpn/tasks/main.yml
+++ b/playbooks/roles/openvpn/tasks/main.yml
@@ -8,15 +8,6 @@
     dest: /etc/dnsmasq.d/openvpn.conf
   notify: Restart dnsmasq
 
-- name: Generate RSA keys for the CA and Server
-  command: openssl genrsa -out {{ item }}.key {{ openvpn_key_size }}
-  args:
-    chdir: "{{ openvpn_path }}"
-    creates: "{{ item }}.key"
-  with_items:
-    - ca
-    - server
-
 - name: Create directories for clients
   file:
     path: "{{ openvpn_path}}/{{ client_name.stdout }}"
@@ -26,98 +17,23 @@
     loop_var: "client_name"
     label: "{{ client_name.item }}"
 
-- name: Generate RSA keys for the clients
-  command: openssl genrsa -out client.key {{ openvpn_key_size }}
-  args:
-    chdir: "{{ openvpn_path }}/{{ client_name.stdout }}"
-    creates: client.key
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-
-- name: Set the proper permissions on all RSA keys
-  file:
-    path: "{{ openvpn_path }}"
-    recurse: yes
-    state: directory
-    owner: root
-    group: root
-    mode: 0600
-
-- name: Generate CA certificate
-  command: openssl req -nodes -batch -new -x509 -key {{ openvpn_ca }}.key -out {{ openvpn_ca }}.crt -days {{ openvpn_days_valid }} -subj "{{ openvpn_request_subject }}/CN=ca-certificate"
-  args:
-    creates: "{{ openvpn_ca }}.crt"
-
-- name: Generate a random server common name
-  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /./g' | cut -c 1-64 > {{ openvpn_server_common_name_file }}
-  args:
-    creates: "{{ openvpn_server_common_name_file }}"
-
-- name: Set permissions on the OpenVPN server common name file
-  file:
-    path: "{{ openvpn_server_common_name_file }}"
-    owner: root
-    group: root
-    mode: 0600
+- include_role:
+    name: certificates
+  vars:
+    ca_path:            "{{ openvpn_path }}"
+    tls_ca:             "{{ openvpn_ca }}"
+    tls_client_path:    "{{ openvpn_path }}"
+    generate_ca_server: yes
+    generate_client:    yes
+    tls_request_subject:         "{{ openvpn_request_subject }}"
+    tls_server_common_name_file: "{{ openvpn_server_common_name_file }}"
+    tls_san:
+      - "{{ streisand_ipv4_address }}"
 
 - name: Register the OpenVPN server common name
-  command: cat {{ openvpn_server_common_name_file }}
+  command: cat "{{ openvpn_server_common_name_file }}"
   register: openvpn_server_common_name
   changed_when: False
-
-- name: Generate the OpenSSL configuration that will be used for the Server certificate's req and ca commands
-  # Properly sets the attributes that are described here:
-  # https://openvpn.net/index.php/open-source/documentation/howto.html#mitm
-  #
-  # This is required for the 'remote-cert-tls server|client' option to
-  # work, which is a recommended practice to help mitigate MITM attacks
-  template:
-    src: openssl-certificate.cnf.j2
-    dest: "{{ openvpn_path }}/openssl-certificate.cnf"
-
-- name: Seed a blank database file that will be used when generating the Server's certificate
-  file:
-    path: "{{ openvpn_path }}/index.txt"
-    state: touch
-
-- name: Seed a serial file that will be used when generating the Server's certificate
-  copy:
-    content: "01"
-    dest: "{{ openvpn_path }}/serial"
-
-- name: Generate CSR for the Server
-  command: openssl req -batch -extensions server -new -key server.key -out server.csr -config {{ openvpn_path }}/openssl-certificate.cnf
-  args:
-    chdir: "{{ openvpn_path }}"
-    creates: server.csr
-
-- name: Generate certificate for the Server
-  command: openssl ca -batch -extensions server -in server.csr -out server.crt -config openssl-certificate.cnf
-  args:
-    chdir: "{{ openvpn_path }}"
-    creates: server.crt
-
-- name: Generate CSRs for the clients
-  command: openssl req -new -extensions client -key client.key -out client.csr -subj "{{ openvpn_request_subject }}/CN={{ client_name.stdout }}" -config {{ openvpn_path }}/openssl-certificate.cnf
-  args:
-    chdir: "{{ openvpn_path }}/{{ client_name.stdout }}"
-    creates: client.csr
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-
-- name: Generate certificates for the clients
-  command: openssl x509 -extensions client -CA {{ openvpn_ca }}.crt -CAkey {{ openvpn_ca }}.key -CAcreateserial -req -days {{ openvpn_days_valid }} -in client.csr -out client.crt -extfile {{ openvpn_path }}/openssl-certificate.cnf
-  args:
-    chdir: "{{ openvpn_path }}/{{ client_name.stdout }}"
-    creates: client.crt
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
 
 - name: Generate HMAC firewall key
   command: openvpn --genkey --secret {{ openvpn_hmac_firewall }}

--- a/playbooks/roles/openvpn/tasks/main.yml
+++ b/playbooks/roles/openvpn/tasks/main.yml
@@ -17,7 +17,7 @@
     loop_var: "client_name"
     label: "{{ client_name.item }}"
 
-- include_role:
+- import_playbook:
     name: certificates
   vars:
     ca_path:            "{{ openvpn_path }}"
@@ -27,7 +27,7 @@
     generate_client:    yes
     tls_request_subject:         "{{ openvpn_request_subject }}"
     tls_server_common_name_file: "{{ openvpn_server_common_name_file }}"
-    tls_san:
+    tls_sans:
       - "{{ streisand_ipv4_address }}"
 
 - name: Register the OpenVPN server common name


### PR DESCRIPTION
This PR aims to refactor CA/Server/Client certificate generation into its own role (in a similar vein as the download-and-veryify role) with the goals of:

 - Reducing code duplication by way of centralizing certificate generation
 - Separation of CA/server and client certificate generation into separate tasks (separation of concerns)
 - Simplify any future endeavor if OpenSSL need be replaced with alternative cryptography toolkits (e.x. LibreSSL)

Additionally, the changes in this PR will now assign subject alternative names to (the self-signed) server certificate, which may help in addressing the issue presented in #906 (to be issued in a separate PR).

The OpenVPN and OpenConnect roles have been refactored to utilize the role, without any observable regressions thus far.
 