### PR TITLE
Fix the default-site ssh_private_key filepath.

### DIFF
--- a/global_vars/default-site.yml
+++ b/global_vars/default-site.yml
@@ -7,7 +7,7 @@
 # The SSH private key that Ansible will use to connect to the Streisand node.
 # The associated public key will be used if required when provisioning cloud
 # nodes for the authorized_keys file.
-streisand_ssh_private_key: "~/.ssh/id-rsa"
+streisand_ssh_private_key: "~/.ssh/id_rsa"
 
 vpn_clients: 5
 


### PR DESCRIPTION
Previous to this commit the `default-site.yml` file that was used to
initialize the user's `~/.streisand/site.yml` used `~/.ssh/id-rsa` as
the default SSH private key file location if one were not specified.

`ssh-keygen` actually uses `~/.ssh/id_rsa` (note the underscore) and so
we should too. This commit updates the default
`streisand_ssh_private_key` value from `default-site.yml` accordingly.

Resolves https://github.com/StreisandEffect/streisand/issues/1001