### PR TITLE
Only generate Mirror page when there is mirrored software.

### DIFF
--- a/playbooks/roles/streisand-gateway/templates/index-fr.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/index-fr.md.j2
@@ -37,12 +37,7 @@ Il existe de multiples façons de contourner la censure, et Streisand vous propo
 * [WireGuard](/wireguard/index-fr.html)
 {% endif %}
 
-{% if (streisand_openconnect_enabled or
-       streisand_openvpn_enabled or
-       streisand_shadowsocks_enabled or
-       streisand_ssh_forward_enabled or
-       streisand_stunnel_enabled or
-       streisand_tor_enabled): %}
+{% if streisand_mirrored_clients %}
 Miroirs des clients
 -------------------
 ---

--- a/playbooks/roles/streisand-gateway/templates/index-fr.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/index-fr.md.j2
@@ -37,6 +37,12 @@ Il existe de multiples façons de contourner la censure, et Streisand vous propo
 * [WireGuard](/wireguard/index-fr.html)
 {% endif %}
 
+{% if (streisand_openconnect_enabled or
+       streisand_openvpn_enabled or
+       streisand_shadowsocks_enabled or
+       streisand_ssh_forward_enabled or
+       streisand_stunnel_enabled or
+       streisand_tor_enabled): %}
 Miroirs des clients
 -------------------
 ---
@@ -60,4 +66,6 @@ Vous pouvez télécharger le logiciel client nécessaire directement auprès de 
 {% endif %}
 {% if streisand_tor_enabled %}
 * [Tor Browser Bundle](/mirror/tor/index-fr.html)
+{% endif %}
+
 {% endif %}

--- a/playbooks/roles/streisand-gateway/templates/index.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/index.md.j2
@@ -37,6 +37,12 @@ There are multiple ways to bypass censorship, and Streisand provides several cho
 * [WireGuard](/wireguard/)
 {% endif %}
 
+{% if (streisand_openconnect_enabled or
+       streisand_openvpn_enabled or
+       streisand_shadowsocks_enabled or
+       streisand_ssh_forward_enabled or
+       streisand_stunnel_enabled or
+       streisand_tor_enabled): %}
 Client Mirrors
 --------------
 ---
@@ -60,4 +66,6 @@ You can download the necessary client software directly from Streisand in case t
 {% endif %}
 {% if streisand_tor_enabled %}
 * [Tor Browser Bundle](/mirror/tor/)
+{% endif %}
+
 {% endif %}

--- a/playbooks/roles/streisand-gateway/templates/index.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/index.md.j2
@@ -37,12 +37,7 @@ There are multiple ways to bypass censorship, and Streisand provides several cho
 * [WireGuard](/wireguard/)
 {% endif %}
 
-{% if (streisand_openconnect_enabled or
-       streisand_openvpn_enabled or
-       streisand_shadowsocks_enabled or
-       streisand_ssh_forward_enabled or
-       streisand_stunnel_enabled or
-       streisand_tor_enabled): %}
+{% if streisand_mirrored_clients %}
 Client Mirrors
 --------------
 ---

--- a/playbooks/roles/streisand-mirror/tasks/main.yml
+++ b/playbooks/roles/streisand-mirror/tasks/main.yml
@@ -12,6 +12,15 @@
     src: mirror-index{{ item.value.file_suffix }}.md.j2
     dest: "{{ streisand_mirror_location }}/index{{ item.value.file_suffix }}.md"
   with_dict: "{{ streisand_languages }}"
+  # Only generate the Markdown mirror page when there is a role enabled that
+  # mirrors client software
+  when: >
+    streisand_openconnect_enabled or
+    streisand_openvpn_enabled or
+    streisand_shadowsocks_enabled or
+    streisand_ssh_forward_enabled or
+    streisand_stunnel_enabled or
+    streisand_tor_enabled
 
 - name: Convert the Markdown mirror page into HTML
   shell: markdown {{ streisand_mirror_location }}/index{{ item.value.file_suffix }}.md | cat {{ streisand_i18n_header_template }} - {{ streisand_footer_template }} > {{ streisand_mirror_location }}/index{{ item.value.file_suffix }}.html

--- a/playbooks/roles/streisand-mirror/tasks/main.yml
+++ b/playbooks/roles/streisand-mirror/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Determine if there is a need to mirror client software
+  # NOTE(@cpu): If any additional roles start to mirror client software this
+  # conditional fact value should be updated to include the role's enabled var.
+  set_fact:
+    streisand_mirrored_clients: >
+      streisand_openconnect_enabled or
+      streisand_openvpn_enabled or
+      streisand_shadowsocks_enabled or
+      streisand_ssh_forward_enabled or
+      streisand_stunnel_enabled or
+      streisand_tor_enabled
+
 - name: Make the directory where mirrored files will be stored
   file:
     path: "{{ streisand_mirror_location }}"
@@ -14,13 +26,7 @@
   with_dict: "{{ streisand_languages }}"
   # Only generate the Markdown mirror page when there is a role enabled that
   # mirrors client software
-  when: >
-    streisand_openconnect_enabled or
-    streisand_openvpn_enabled or
-    streisand_shadowsocks_enabled or
-    streisand_ssh_forward_enabled or
-    streisand_stunnel_enabled or
-    streisand_tor_enabled
+  when: streisand_mirrored_clients
 
 - name: Convert the Markdown mirror page into HTML
   shell: markdown {{ streisand_mirror_location }}/index{{ item.value.file_suffix }}.md | cat {{ streisand_i18n_header_template }} - {{ streisand_footer_template }} > {{ streisand_mirror_location }}/index{{ item.value.file_suffix }}.html


### PR DESCRIPTION
If no roles are enabled that mirror client software then the index page
shouldn't reference a mirrored software page and we should not generate
one.

Resolves https://github.com/StreisandEffect/streisand/issues/961