### PR TITLE
Set up a simple noninteractive deployment mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,34 @@ The server must be accessible using the `$HOME/id_rsa` SSH Key, and **root** is 
 
 **Note:** Running Streisand against an existing server can be a destructive action! You will be potentially overwriting configuration files and must be certain that you are affecting the correct machine.
 
+### Noninteractive Deployment (Advanced) ###
+
+Alternative scripts and configuration file examples are provided for
+noninteractive deployment, in which all of the required information is passed
+on the command line or in a configuration file.
+
+Example configuration files are found under `global_vars/noninteractive`. Copy
+and edit the desired parameters, such as providing API tokens and other choices,
+and then run the appropriate script.
+
+To deploy a new Streisand server:
+
+      deploy/streisand-new-cloud-server.sh \
+        --provider digitalocean \
+        --site-config global_vars/noninteractive/digitalocean-site.yml
+
+To run the Streisand provisioning on the local machine:
+
+      deploy/streisand-local.sh \
+        --site-config global_vars/noninteractive/local-site.yml
+
+To run the Streisand provisioning against an existing server:
+
+      deploy/streisand-existing-cloud-server.sh \
+        --ip-address 10.10.10.10 \
+        --ssh-user root \
+        --site-config global_vars/noninteractive/digitalocean-site.yml
+
 Upcoming Features
 -----------------
 * Easier setup.

--- a/deploy/streisand-existing-cloud-server.sh
+++ b/deploy/streisand-existing-cloud-server.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Provision an existing cloud server.
+#
+# This requires an expanded extra-vars file specific to the provider type that
+# sets all of the values gathered by prompts in the interactive installation.
+# See the contents of global_vars/noninteractive for examples that can be copied
+# and modified.
+#
+# Usage:
+#
+# streisand-existing-cloud-server \
+#   --ssh-user root \
+#   --ip-address 10.10.10.10 \
+#   --site-config path/to/digitalocean-site.yml
+#
+
+set -o errexit
+set -o nounset
+
+DIR="$( cd "$( dirname "$0" )" && pwd)"
+PROJECT_DIR="${DIR}/.."
+
+export DEFAULT_SITE_VARS="${PROJECT_DIR}/global_vars/default-site.yml"
+export GLOBAL_VARS="${PROJECT_DIR}/global_vars/vars.yml"
+
+# Include the check_ansible function from ansible_check.sh.
+# shellcheck source=util/source_validate_and_deploy.sh
+source "${PROJECT_DIR}/util/ansible_check.sh"
+check_ansible
+
+# --------------------------------------------------------------------------
+# Reading options.
+# --------------------------------------------------------------------------
+
+function usage () {
+  cat <<EOF
+Usage:
+$0 \\
+  --ssh-user root \\
+  --ip-address 10.10.10.10 \\
+  --site-config path/to/site.yml
+
+If no SSH user is specified, then the root user will be used.
+
+If no configuration file is specified, then ~/.streisand/site.yml will be used
+if it exists, or global_vars/default-site.yml will be used otherwise.
+EOF
+}
+
+SSH_USER=""
+IP_ADDRESS=""
+SITE_VARS=""
+
+while [[ ${#} -gt 0 ]]; do
+  case "${1}" in
+    # Required.
+    --ip-address)    IP_ADDRESS="${2}"; shift;;
+
+    # Optional.
+    --site-config)   SITE_VARS="${2}"; shift;;
+    --ssh-user)      SSH_USER="${2}"; shift;;
+
+    # Utility.
+    -h|--help)       usage; exit 0;;
+    --)              break;;
+    -*)              echo "Unrecognized option ${1}"; usage; exit 1;;
+  esac
+
+  shift
+done
+
+# --------------------------------------------------------------------------
+# Fail if required options are not set.
+# --------------------------------------------------------------------------
+
+if [ -z "${IP_ADDRESS}" ]; then
+  usage
+  exit 1
+fi
+
+# --------------------------------------------------------------------------
+# Default if no parameter is provided.
+# --------------------------------------------------------------------------
+
+if [ -z "${SSH_USER}" ]; then
+  echo "Defaulting to SSH user: root"
+  SSH_USER="root"
+fi
+
+# --------------------------------------------------------------------------
+# Sort out the SITE_VARS value based on input and defaults.
+# --------------------------------------------------------------------------
+
+# shellcheck source=util/source_check_and_default_site_vars.sh
+source "${PROJECT_DIR}/util/source_check_and_default_site_vars.sh"
+
+# --------------------------------------------------------------------------
+# Onwards to launch and provision the server.
+# --------------------------------------------------------------------------
+
+export INVENTORY="${PROJECT_DIR}/inventories/inventory-existing"
+
+# Create an inventory file on the fly.
+cat > "${INVENTORY}" <<EOF
+[localhost]
+localhost ansible_connection=local ansible_python_interpreter=python
+[streisand-host]
+${IP_ADDRESS} ansible_user=${SSH_USER}
+EOF
+
+export PLAYBOOK="${PROJECT_DIR}/playbooks/existing-server.yml"
+
+# Run the validation and deployment. This expects the variables set here.
+# shellcheck source=util/source_validate_and_deploy.sh
+source "${PROJECT_DIR}/util/source_validate_and_deploy.sh"

--- a/deploy/streisand-local.sh
+++ b/deploy/streisand-local.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Run a noninteractive Streisand installation on the local machine.
+#
+# This requires an expanded extra-vars file specific to the provider type that
+# sets all of the values gathered by prompts in the interactive installation.
+# See the contents of global_vars/noninteractive for examples that can be copied
+# and modified.
+#
+# Usage:
+#
+# streisand-local --site-config path/to/local-site.yml
+#
+
+set -o errexit
+set -o nounset
+
+DIR="$( cd "$( dirname "$0" )" && pwd)"
+PROJECT_DIR="${DIR}/.."
+
+export DEFAULT_SITE_VARS="${PROJECT_DIR}/global_vars/default-site.yml"
+export GLOBAL_VARS="${PROJECT_DIR}/global_vars/vars.yml"
+
+# Include the check_ansible function from ansible_check.sh.
+# shellcheck source=util/source_validate_and_deploy.sh
+source "${PROJECT_DIR}/util/ansible_check.sh"
+check_ansible
+
+# --------------------------------------------------------------------------
+# Reading options.
+# --------------------------------------------------------------------------
+
+function usage () {
+  cat <<EOF
+Usage:
+$0 --site-config path/to/site.yml
+
+If no configuration file is specified, then ~/.streisand/site.yml will be used
+if it exists, or global_vars/default-site.yml will be used otherwise.
+EOF
+}
+
+SITE_VARS=""
+
+while [[ ${#} -gt 0 ]]; do
+  case "${1}" in
+    # Optional.
+    --site-config)   SITE_VARS="${2}"; shift;;
+
+    # Utility.
+    -h|--help)       usage; exit 0;;
+    --)              break;;
+    -*)              echo "Unrecognized option ${1}"; usage; exit 1;;
+  esac
+
+  shift
+done
+
+# --------------------------------------------------------------------------
+# Sort out the SITE_VARS value based on input and defaults.
+# --------------------------------------------------------------------------
+
+# shellcheck source=util/source_check_and_default_site_vars.sh
+source "${PROJECT_DIR}/util/source_check_and_default_site_vars.sh"
+
+# --------------------------------------------------------------------------
+# Onwards to provision the local machine.
+# --------------------------------------------------------------------------
+
+export INVENTORY="${PROJECT_DIR}/inventories/inventory-local-provision"
+export PLAYBOOK="${PROJECT_DIR}/playbooks/localhost.yml"
+
+# Run the validation and deployment. This expects the variables set here.
+# shellcheck source=util/source_validate_and_deploy.sh
+source "${PROJECT_DIR}/util/source_validate_and_deploy.sh"

--- a/deploy/streisand-new-cloud-server.sh
+++ b/deploy/streisand-new-cloud-server.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Run a noninteractive Streisand installation that creates a new cloud server.
+#
+# This requires an expanded extra-vars file specific to the provider type that
+# sets all of the values gathered by prompts in the interactive installation.
+# See the contents of global_vars/noninteractive for examples that can be copied
+# and modified.
+#
+# Usage:
+# streisand-new-cloud-server \
+#   --provider [amazon|azure|digitalocean|google|linode|rackspace] \
+#   --site-config path/to/digitalocean-site.yml
+#
+
+set -o errexit
+set -o nounset
+
+DIR="$( cd "$( dirname "$0" )" && pwd)"
+PROJECT_DIR="${DIR}/.."
+
+VALID_PROVIDERS="amazon|azure|digitalocean|google|linode|rackspace"
+export DEFAULT_SITE_VARS="${PROJECT_DIR}/global_vars/default-site.yml"
+export GLOBAL_VARS="${PROJECT_DIR}/global_vars/vars.yml"
+
+# Include the check_ansible function from ansible_check.sh.
+# shellcheck source=util/source_validate_and_deploy.sh
+source "${PROJECT_DIR}/util/ansible_check.sh"
+check_ansible
+
+# --------------------------------------------------------------------------
+# Reading options.
+# --------------------------------------------------------------------------
+
+function usage () {
+  cat <<EOF
+Usage:
+$0 \\
+  --provider [${VALID_PROVIDERS}] \\
+  --site-config path/to/site.yml
+
+If no configuration file is specified, then ~/.streisand/site.yml will be used
+if it exists, or global_vars/default-site.yml will be used otherwise.
+EOF
+}
+
+PROVIDER=""
+SITE_VARS=""
+
+while [[ ${#} -gt 0 ]]; do
+  case "${1}" in
+    # Required.
+    --provider)      PROVIDER="${2}"; shift;;
+
+    # Optional.
+    --site-config)   SITE_VARS="${2}"; shift;;
+
+    # Utility.
+    -h|--help)       usage; exit 0;;
+    --)              break;;
+    -*)              echo "Unrecognized option ${1}"; usage; exit 1;;
+  esac
+
+  shift
+done
+
+# --------------------------------------------------------------------------
+# Check the provider parameter.
+# --------------------------------------------------------------------------
+
+# Was it passed in at all?
+if [ -z "${PROVIDER}" ]; then
+  usage
+  exit 1
+fi
+
+# Check validity of the provider name.
+if [[ ! "${PROVIDER}" =~ ${VALID_PROVIDERS} ]]; then
+  echo "Invalid provider: ${PROVIDER}"
+  exit 1
+fi
+
+# --------------------------------------------------------------------------
+# Sort out the SITE_VARS value based on input and defaults.
+# --------------------------------------------------------------------------
+
+# shellcheck source=util/source_check_and_default_site_vars.sh
+source "${PROJECT_DIR}/util/source_check_and_default_site_vars.sh"
+
+# --------------------------------------------------------------------------
+# Onwards to launch and provision the server.
+# --------------------------------------------------------------------------
+
+export INVENTORY="${PROJECT_DIR}/inventories/inventory"
+export PLAYBOOK="${PROJECT_DIR}/playbooks/${PROVIDER}.yml"
+
+# Run the validation and deployment. This expects the variables set here.
+# shellcheck source=util/source_validate_and_deploy.sh
+source "${PROJECT_DIR}/util/source_validate_and_deploy.sh"
+

--- a/global_vars/noninteractive/amazon-site.yml
+++ b/global_vars/noninteractive/amazon-site.yml
@@ -1,0 +1,68 @@
+---
+# Example site specific configuration for a noninteractive AWS deployment.
+#
+# Copy this and edit it as needed before running streisand-new-cloud-server.
+#
+
+streisand_noninteractive: true
+confirmation: true
+
+# The SSH private key that Ansible will use to connect to the Streisand node.
+#
+# This will be added to the AWS console and given the name streisand-ssh.
+streisand_ssh_private_key: "~/.ssh/id_rsa"
+
+vpn_clients: 5
+
+streisand_l2tp_enabled: yes
+streisand_openconnect_enabled: yes
+streisand_openvpn_enabled: yes
+streisand_shadowsocks_enabled: yes
+streisand_ssh_forward_enabled: yes
+# By default sshuttle is disabled because it creates a `sshuttle` user that has
+# full shell privileges on the Streisand host
+streisand_sshuttle_enabled: no
+streisand_stunnel_enabled: yes
+streisand_tinyproxy_enabled: yes
+streisand_tor_enabled: yes
+streisand_wireguard_enabled: yes
+
+# The AWS region number.
+# 1. Asia Pacific   (Mumbai)
+# 2. Asia Pacific   (Seoul)
+# 3. Asia Pacific   (Singapore)
+# 4. Asia Pacific   (Sydney)
+# 5. Asia Pacific   (Tokyo)
+# 6. Canada         (Central)
+# 7. EU             (Frankfurt)
+# 8. EU             (Ireland)
+# 9. EU             (London)
+# 10. South America (Sao Paulo)
+# 11. US East       (Northern Virginia)
+# 12. US East       (Ohio)
+# 13. US West       (Northern California)
+# 14. US West       (Oregon)
+#
+# Note: aws_region_var must be a number in quotes, e.g. "3" not 3.
+aws_region_var: "3"
+
+# The VPC and subnet IDs to use. They can be empty strings to indicate that a
+# VPC will not be used.
+aws_vpc_id_var: ""
+aws_vpc_subnet_id_var: ""
+
+aws_instance_name: streisand
+
+# The AWS credentials to use.
+aws_access_key: ""
+aws_secret_key: ""
+
+# Definitions needed for Let's Encrypt HTTPS (or TLS) certificate setup.
+#
+# If these are both left as empty strings, Let's Encrypt will not be set up and
+# a self-signed certificate will be used instead.
+#
+# The domain to use for Let's Encrypt certificate.
+streisand_domain_var: ""
+# The admin email address for Let's Encrypt certificate registration.
+streisand_admin_email_var: ""

--- a/global_vars/noninteractive/azure-site.yml
+++ b/global_vars/noninteractive/azure-site.yml
@@ -1,0 +1,89 @@
+---
+# Example site specific configuration for a noninteractive Azure deployment.
+#
+# Copy this and edit it as needed before running streisand-new-cloud-server.
+#
+# Ensure that you have the azure credentials file set up at ~/.azure/credentials
+#
+
+streisand_noninteractive: true
+confirmation: true
+
+# The SSH private key that Ansible will use to connect to the Streisand node.
+streisand_ssh_private_key: "~/.ssh/id_rsa"
+
+vpn_clients: 5
+
+streisand_l2tp_enabled: yes
+streisand_openconnect_enabled: yes
+streisand_openvpn_enabled: yes
+streisand_shadowsocks_enabled: yes
+streisand_ssh_forward_enabled: yes
+# By default sshuttle is disabled because it creates a `sshuttle` user that has
+# full shell privileges on the Streisand host
+streisand_sshuttle_enabled: no
+streisand_stunnel_enabled: yes
+streisand_tinyproxy_enabled: yes
+streisand_tor_enabled: yes
+streisand_wireguard_enabled: yes
+
+# The region to deploy into.
+#
+# North America:
+#    1: East US             (Virginia)
+#    2: East US 2           (Virginia)
+#    3: Central US          (Iowa)
+#    4: North Central US    (Illinois)
+#    5: South Central US    (Texas)
+#    6: West Central US     (West Central US)
+#    7: West US             (California)
+#    8: West US 2           (West US 2)
+#    9: US Gov Virginia     (Virginia)
+#   10: US Gov Iowa         (Iowa)
+#   11: US DoD East         (US DoD East)
+#   12: US DoD Central      (US DoD Central)
+#   13: Canada East         (Quebec City)
+#   14: Canada Central      (Toronto)
+#
+# South America:
+#   15: Brazil South        (Sao Paulo State)
+#
+# Asia:
+#   16: Southeast Asia      (Singapore)
+#   17: East Asia           (Hong Kong)
+#   18: China East          (Shanghai)
+#   19: China North         (Beijing)
+#   20: Japan East          (Tokyo, Saitama)
+#   21: Japan West          (Osaka)
+#   22: Korea Central       (Seoul)
+#   23: Korea South         (Busan)
+#   24: Central India       (Pune)
+#   25: West India          (Mumbai)
+#   26: South India         (Chennai)
+#
+# Australia:
+#   27: Australia East      (New South Wales)
+#   28: Australia Southeast (Victoria)
+#
+# Europe:
+#   29: North Europe        (Ireland)
+#   30: West Europe         (Netherlands)
+#   31: Germany Central     (Frankfurt)
+#   32: Germany Northeast   (Magdeburg)
+#   33: UK West             (Cardiff)
+#   34: UK South            (London)
+#
+# Note: azure_region_var must be a number in quotes, e.g. "1" not 1.
+azure_region_var: "1"
+
+azure_instance_name_var: streisand
+
+# Definitions needed for Let's Encrypt HTTPS (or TLS) certificate setup.
+#
+# If these are both left as empty strings, Let's Encrypt will not be set up and
+# a self-signed certificate will be used instead.
+#
+# The domain to use for Let's Encrypt certificate.
+streisand_domain_var: ""
+# The admin email address for Let's Encrypt certificate registration.
+streisand_admin_email_var: ""

--- a/global_vars/noninteractive/digitalocean-site.yml
+++ b/global_vars/noninteractive/digitalocean-site.yml
@@ -1,0 +1,68 @@
+---
+# Example site specific configuration for a noninteractive Digital Ocean
+# deployment.
+#
+# Copy this and edit it as needed before running streisand-new-cloud-server.
+#
+
+streisand_noninteractive: true
+confirmation: true
+
+# The SSH private key that Ansible will use to connect to the Streisand node.
+#
+# The corresponding public key must be added to the Digital Ocean control panel
+# and the name given to it referenced below in the do_ssh_name variable.
+# The corresponding public key must be uploaded to Digital Ocean and the name
+# given to it referenced below in the do_ssh_name variable.
+streisand_ssh_private_key: "~/.ssh/id_rsa"
+
+vpn_clients: 5
+
+streisand_l2tp_enabled: yes
+streisand_openconnect_enabled: yes
+streisand_openvpn_enabled: yes
+streisand_shadowsocks_enabled: yes
+streisand_ssh_forward_enabled: yes
+# By default sshuttle is disabled because it creates a `sshuttle` user that has
+# full shell privileges on the Streisand host
+streisand_sshuttle_enabled: no
+streisand_stunnel_enabled: yes
+streisand_tinyproxy_enabled: yes
+streisand_tor_enabled: yes
+streisand_wireguard_enabled: yes
+
+# The Digital Ocean region number.
+#
+# 1.  Amsterdam        (Datacenter 2)
+# 2.  Amsterdam        (Datacenter 3)
+# 3.  Bangalore
+# 4.  Frankfurt
+# 5.  London
+# 6.  New York         (Datacenter 1)
+# 7.  New York         (Datacenter 2)
+# 8.  New York         (Datacenter 3)
+# 9.  San Francisco    (Datacenter 1)
+# 10. San Francisco    (Datacenter 2)
+# 11. Singapore
+# 12. Toronto
+#
+# Note: do_region must be a number in quotes, e.g. "2" not 2.
+do_region: "2"
+
+do_server_name: streisand
+
+# Add the Digital Ocean access token here.
+do_access_token_entry: ""
+
+# The name given to the key in the DigitalOcean control panel.
+do_ssh_name: streisand
+
+# Definitions needed for Let's Encrypt HTTPS (or TLS) certificate setup.
+#
+# If these are both left as empty strings, Let's Encrypt will not be set up and
+# a self-signed certificate will be used instead.
+#
+# The domain to use for Let's Encrypt certificate.
+streisand_domain_var: ""
+# The admin email address for Let's Encrypt certificate registration.
+streisand_admin_email_var: ""

--- a/global_vars/noninteractive/google-site.yml
+++ b/global_vars/noninteractive/google-site.yml
@@ -1,0 +1,79 @@
+---
+# Example site specific configuration for a noninteractive Google Compute Engine
+# deployment.
+#
+# Copy this and edit it as needed before running streisand-new-cloud-server.
+#
+
+streisand_noninteractive: true
+confirmation: true
+
+# The SSH private key that Ansible will use to connect to the Streisand node.
+streisand_ssh_private_key: "~/.ssh/id_rsa"
+
+vpn_clients: 5
+
+streisand_l2tp_enabled: yes
+streisand_openconnect_enabled: yes
+streisand_openvpn_enabled: yes
+streisand_shadowsocks_enabled: yes
+streisand_ssh_forward_enabled: yes
+# By default sshuttle is disabled because it creates a `sshuttle` user that has
+# full shell privileges on the Streisand host
+streisand_sshuttle_enabled: no
+streisand_stunnel_enabled: yes
+streisand_tinyproxy_enabled: yes
+streisand_tor_enabled: yes
+streisand_wireguard_enabled: yes
+
+# Server location:
+#
+# 1. Central US            (Iowa A)
+# 2. Central US            (Iowa B)
+# 3. Central US            (Iowa C)
+# 4. Central US            (Iowa F)
+# 5. Eastern US            (Northern Virginia B)
+# 6. Eastern US            (Northern Virginia C)
+# 7. Eastern US            (Northern Virginia D)
+# 8. Eastern US            (South Carolina B)
+# 9. Eastern US            (South Carolina C)
+# 10. Eastern US           (South Carolina D)
+# 11. Western US           (Oregon A)
+# 12. Western US           (Oregon B)
+# 13. Western Europe       (Belgium B)
+# 14. Western Europe       (Belgium C)
+# 15. Western Europe       (Belgium D)
+# 16. East Asia            (Taiwan A)
+# 17. East Asia            (Taiwan B)
+# 18. East Asia            (Taiwan C)
+# 19. Northeast Asia       (Tokyo A)
+# 20. Northeast Asia       (Tokyo B)
+# 21. Northeast Asia       (Tokyo C)
+# 22. Southeast Asia       (Singapore A)
+# 23. Southeast Asia       (Singapore B)
+# 24. Southeast Australia  (Sydney A)
+# 25. Southeast Australia  (Sydney B)
+# 26. Southeast Australia  (Sydney C)
+# 27. South America        (São Paulo A)
+# 28. South America        (São Paulo B)
+# 29. South America        (São Paulo C)
+#
+# Note: gce_zone_var must be a number in quotes, e.g. "3" not 3.
+gce_zone_var: "3"
+
+gce_server_name: streisand
+
+# The full path of your unique service account credentials file. See:
+# https://docs.ansible.com/ansible/guide_gce.html#credentials
+# https://support.google.com/cloud/answer/6158849?hl=en&ref_topic=6262490#serviceaccounts
+gce_json_file_location: ""
+
+# Definitions needed for Let's Encrypt HTTPS (or TLS) certificate setup.
+#
+# If these are both left as empty strings, Let's Encrypt will not be set up and
+# a self-signed certificate will be used instead.
+#
+# The domain to use for Let's Encrypt certificate.
+streisand_domain_var: ""
+# The admin email address for Let's Encrypt certificate registration.
+streisand_admin_email_var: ""

--- a/global_vars/noninteractive/linode-site.yml
+++ b/global_vars/noninteractive/linode-site.yml
@@ -1,0 +1,55 @@
+---
+# Example site specific configuration for a noninteractive Linode deployment.
+#
+# Copy this and edit it as needed before running streisand-new-cloud-server.
+#
+
+streisand_noninteractive: true
+confirmation: true
+
+# The SSH private key that Ansible will use to connect to the Streisand node.
+streisand_ssh_private_key: "~/.ssh/id_rsa"
+
+vpn_clients: 5
+
+streisand_l2tp_enabled: yes
+streisand_openconnect_enabled: yes
+streisand_openvpn_enabled: yes
+streisand_shadowsocks_enabled: yes
+streisand_ssh_forward_enabled: yes
+# By default sshuttle is disabled because it creates a `sshuttle` user that has
+# full shell privileges on the Streisand host
+streisand_sshuttle_enabled: no
+streisand_stunnel_enabled: yes
+streisand_tinyproxy_enabled: yes
+streisand_tor_enabled: yes
+streisand_wireguard_enabled: yes
+
+# Choose the server location.
+# 1. Atlanta
+# 2. Dallas
+# 3. Frankfurt
+# 4. Fremont
+# 5. London
+# 6. Newark
+# 7. Singapore
+# 8. Tokyo
+# 9. Tokyo 2
+#
+# Note: linode_datacenter must be a number in quotes, e.g. "7" not 7.
+linode_datacenter: "7"
+
+linode_server_name: streisand
+
+# Obtain the API key from the Linode Manager console.
+linode_api_key: ""
+
+# Definitions needed for Let's Encrypt HTTPS (or TLS) certificate setup.
+#
+# If these are both left as empty strings, Let's Encrypt will not be set up and
+# a self-signed certificate will be used instead.
+#
+# The domain to use for Let's Encrypt certificate.
+streisand_domain_var: ""
+# The admin email address for Let's Encrypt certificate registration.
+streisand_admin_email_var: ""

--- a/global_vars/noninteractive/local-site.yml
+++ b/global_vars/noninteractive/local-site.yml
@@ -1,0 +1,37 @@
+---
+# Example site specific configuration for a noninteractive local machine
+# deployment.
+#
+# Copy this and edit it as needed before running streisand-local.
+#
+
+streisand_noninteractive: true
+confirmation: true
+
+# Change this to the location of a key on the local system.
+streisand_ssh_private_key: "~/.ssh/id_rsa"
+
+vpn_clients: 5
+
+streisand_l2tp_enabled: yes
+streisand_openconnect_enabled: yes
+streisand_openvpn_enabled: yes
+streisand_shadowsocks_enabled: yes
+streisand_ssh_forward_enabled: yes
+# By default sshuttle is disabled because it creates a `sshuttle` user that has
+# full shell privileges on the Streisand host
+streisand_sshuttle_enabled: no
+streisand_stunnel_enabled: yes
+streisand_tinyproxy_enabled: yes
+streisand_tor_enabled: yes
+streisand_wireguard_enabled: yes
+
+# Definitions needed for Let's Encrypt HTTPS (or TLS) certificate setup.
+#
+# If these are both left as empty strings, Let's Encrypt will not be set up and
+# a self-signed certificate will be used instead.
+#
+# The domain to use for Let's Encrypt certificate.
+streisand_domain_var: ""
+# The admin email address for Let's Encrypt certificate registration.
+streisand_admin_email_var: ""

--- a/global_vars/noninteractive/rackspace-site.yml
+++ b/global_vars/noninteractive/rackspace-site.yml
@@ -1,0 +1,53 @@
+---
+# Example site specific configuration for a noninteractive Rackspace deployment.
+#
+# Copy this and edit it as needed before running streisand-new-cloud-server.
+#
+
+streisand_noninteractive: true
+confirmation: true
+
+# The SSH private key that Ansible will use to connect to the Streisand node.
+streisand_ssh_private_key: "~/.ssh/id_rsa"
+
+vpn_clients: 5
+
+streisand_l2tp_enabled: yes
+streisand_openconnect_enabled: yes
+streisand_openvpn_enabled: yes
+streisand_shadowsocks_enabled: yes
+streisand_ssh_forward_enabled: yes
+# By default sshuttle is disabled because it creates a `sshuttle` user that has
+# full shell privileges on the Streisand host
+streisand_sshuttle_enabled: no
+streisand_stunnel_enabled: yes
+streisand_tinyproxy_enabled: yes
+streisand_tor_enabled: yes
+streisand_wireguard_enabled: yes
+
+# Choose the region to deploy into.
+#
+# 1. Chicago
+# 2. Dallas
+# 3. Hong Kong
+# 4. Northern Virginia
+# 5. Sydney
+#
+# Note: rackspace_region must be a number in quotes, e.g. "1" not 1.
+rackspace_region: "1"
+
+rackspace_server_name: streisand
+
+# Obtain these credentials from the Rackspace Cloud Control Panel.
+rackspace_username: ""
+rackspace_api_key: ""
+
+# Definitions needed for Let's Encrypt HTTPS (or TLS) certificate setup.
+#
+# If these are both left as empty strings, Let's Encrypt will not be set up and
+# a self-signed certificate will be used instead.
+#
+# The domain to use for Let's Encrypt certificate.
+streisand_domain_var: ""
+# The admin email address for Let's Encrypt certificate registration.
+streisand_admin_email_var: ""

--- a/playbooks/provider-detect.yml
+++ b/playbooks/provider-detect.yml
@@ -42,6 +42,7 @@
         - name: Warn about manual provisioning of GCE instances
           pause:
             prompt: "You are running Streisand in an advanced mode against an existing GCE instance. Unlike the standard GCE provisioning mode this means Streisand *CAN NOT* open ports on your behalf. You will need to manually create the correct VPC Network and firewall rules. See 'generated-docs/' for the firewall-information.html file at the end of installation for a list of ports to open. The Streisand maintainers are not able to support this configuration. Press [enter] to continue"
+          when: not streisand_noninteractive
 
         - name: "Find the external GCE IP from Google Metadata"
           # NOTE: We use the command module and `curl` here because (AFAICT)
@@ -66,6 +67,7 @@
         - name: Warn about manual provisioning of EC2 instances
           pause:
             prompt: "You are running Streisand in an advanced mode against an existing Amazon EC2 instance. Unlike the standard EC2 provisioning mode this means Streisand *CAN NOT* open ports on your behalf. You will need to manually assinging this machine to a security group with the correct firewall rules. See 'generated-docs/' for the firewall-information.html file at the end of installation for a list of ports to open. The Streisand maintainers are not able to support this configuration. Press [enter] to continue"
+          when: not streisand_noninteractive
 
             # EC2 Instance Metadata API is explained in the EC2 docs[0].
             # [0]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Warn users if the server's Linux distribution is not Ubuntu 16.04
   pause:
     prompt: "Ubuntu 16.04 is the only officially supported distribution; the setup will probably fail. Press Enter if you still want to continue."
-  when: ansible_distribution != "Ubuntu" or ansible_distribution_version != "16.04"
+  when: not streisand_noninteractive and (ansible_distribution != "Ubuntu" or ansible_distribution_version != "16.04")
 
 # Set default variables
 - import_tasks: set-default-variables.yml

--- a/playbooks/roles/download-and-verify/tasks/main.yml
+++ b/playbooks/roles/download-and-verify/tasks/main.yml
@@ -37,5 +37,5 @@
   register: gpg_verification_results
   changed_when: False
 
-- name: Make sure the {{ project_name }} files all passed GPG signature verfication
+- name: Make sure the {{ project_name }} files all passed GPG signature verification
   assert: { that: "'BAD signature' not in gpg_verification_results.stderr" }

--- a/playbooks/roles/tor-bridge/tasks/mirror-verify.yml
+++ b/playbooks/roles/tor-bridge/tasks/mirror-verify.yml
@@ -5,5 +5,5 @@
     chdir: "{{ tor_mirror_location }}"
   register: gpg_verification_results
 
-- name: Make sure the {{ tor_project_name }} files all passed GPG signature verfication
+- name: Make sure the {{ tor_project_name }} files all passed GPG signature verification
   assert: { that: "'BAD signature' not in gpg_verification_results.stderr" }

--- a/streisand
+++ b/streisand
@@ -60,36 +60,6 @@ function validate() {
 # change the base installation by rewriting the $SITE_VARS file.
 function customize() {
   read -r -p "
-Do you wish to customize this Streisand installation?
-Please enter the word 'yes' or hit enter to continue: " confirm
-  case "$confirm" in
-    yes) echo; echo "Confirmed. Customizing Streisand.";
-         # NOTE(@cpu): We don't pass the other `--extra-vars` here because the
-         # customize `vars_prompt` will only happen if the vars aren't already
-         # set. If you pass the site/defaults in no prompting will happen.
-         echo; echo; ansible-playbook \
-           --extra-vars="@$GLOBAL_VARS" \
-           playbooks/customize.yml;;
-    *) echo; echo "Installing Streisand services specified in $SITE_VARS";;
-  esac
-}
-
-# validate runs the validation role to check the consistency of the Streisand
-# service vars (e.g. that at least one service is enabled after customization of
-# $SITE_VARS).
-function validate() {
-  echo; echo; ansible-playbook \
-    --extra-vars="@$GLOBAL_VARS" \
-    --extra-vars="@$DEFAULT_SITE_VARS" \
-    --extra-vars="@$SITE_VARS" \
-    playbooks/validate.yml
-}
-
-# customize prompts the user to decide if they want to customize the Streisand
-# installation. If the user wishes, the playbooks/customize.yml role is used to
-# change the base installation by rewriting the $SITE_VARS file.
-function customize() {
-  read -r -p "
 Do you wish to customize which services Streisand will install?
 Please enter the word 'yes' or hit enter to continue: " confirm
   case "$confirm" in

--- a/util/ansible_check.sh
+++ b/util/ansible_check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Set errexit option to exit immediately on any non-zero status return
+# Set errexit option to exit immediately on any non-zero status return.
 set -e
 
 # check_ansible checks that Ansible is installed on the local system

--- a/util/source_check_and_default_site_vars.sh
+++ b/util/source_check_and_default_site_vars.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# This is intended to be sourced into a deploy script. It exists to DRY up the
+# codebase. It expects the following variables set:
+#
+# DEFAULT_SITE_VARS /path/to/default-site.yml
+# PROJECT_DIR /path/to/streisand
+# SITE_VARS /path/to/site.yml
+#
+
+set -o errexit
+
+# If no site vars file is provided, then use one of the two default options.
+if [ -z "${SITE_VARS}" ]; then
+
+  SITE_VARS="${HOME}/.streisand/site.yml"
+
+  if [ ! -f "${SITE_VARS}" ]; then
+    SITE_VARS="${DEFAULT_SITE_VARS}"
+  fi
+
+  echo "Using default config file: ${SITE_VARS}"
+fi
+
+# Make sure the alleged configuration file exists.
+if [ ! -f "${SITE_VARS}" ]; then
+  echo "No such config file: ${SITE_VARS}"
+  exit 1
+fi

--- a/util/source_validate_and_deploy.sh
+++ b/util/source_validate_and_deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# This is intended to be sourced into a deploy script. It exists to DRY up the
+# codebase. It expects the following variables set:
+#
+# DEFAULT_SITE_VARS /path/to/default-site.yml
+# GLOBAL_VARS /path/to/vars.yml
+# INVENTORY /path/to/inventory
+# PROJECT_DIR /path/to/streisand
+# SITE_VARS /path/to/site.yml
+# PLAYBOOK /path/to/playbook.yml.
+#
+
+set -o errexit
+
+ansible-playbook \
+  --extra-vars="@${GLOBAL_VARS}" \
+  --extra-vars="@${DEFAULT_SITE_VARS}" \
+  --extra-vars="@${SITE_VARS}" \
+  "${PROJECT_DIR}/playbooks/validate.yml"
+
+# Update the server.
+ansible-playbook \
+  -i "${INVENTORY}" \
+  --extra-vars="@${GLOBAL_VARS}" \
+  --extra-vars="@${DEFAULT_SITE_VARS}" \
+  --extra-vars="@${SITE_VARS}" \
+  "${PLAYBOOK}"


### PR DESCRIPTION
This PR is a proposed simple noninteractive deployment.

- Make a few changes to Ansible where needed to allow some prompts to be bypassed.
- Provide example vars files.
- Create some additional bash scripts to run non-interactive deployments.
- Remove duplicate function definitions from the `streisand` script.
- Add English documentation on running the new scripts.

It is possible, somewhat, to shoehorn all of the new bash scripting into the main `streisand` script, but it gets pretty ugly with if-blocks and checks if you do that. I'm not in favor of kitchen sink scripts - the code is much simpler and more maintainable when split out in this way.

Example configuration files are found under `global_vars/noninteractive`. Copy and edit the desired parameters, such as providing API tokens and other choices, and then run the appropriate script.

To deploy a new Streisand server:

```
 deploy/streisand-new-cloud-server \
  --provider digitalocean \
  --site-config global_vars/noninteractive/digitalocean-site.yml
```

To run the Streisand provisioning on the local machine:

```
deploy/streisand-local \
   --site-config global_vars/noninteractive/local-site.yml
```

To rerun the Streisand provisioning an existing server:

```
deploy/streisand-existing-cloud-server \
  --ip-address 10.10.10.10 \
  --ssh-user root \
  --site-config global_vars/noninteractive/local-site.yml
```