### PR TITLE
Refactor certificates role

### DIFF
--- a/documentation/certificates.md
+++ b/documentation/certificates.md
@@ -22,16 +22,15 @@ certificate signed by the newly minted certificate authority.
 
 Client
 ------
-Guarded by `generate_client: yes`
+Generate client certificates using the CA from `generate_ca_server: yes`. 
+These client certificates can be used by VPN clients to authenticate with 
+VPN services on the server.
 
-Generate client side certificates using the same CA used for authenticating
-connecting VPN clients.
-
-Client PKCS
------------
+Client (PKCS#11 format)
+-----------------------
 Guarded by `generate_pkcs: yes`
 
-Generate client PKCS files.
+Also convert client certificates into PKCS#12 format.
 
 Infrastructure
 --------------
@@ -50,9 +49,6 @@ OpenConnect CA:
    \__ OpenConnect client 1
    \__ OpenConnect client ...
    \__ OpenConnect client n
-      \__ OpenConnect client PKCS 1
-      \__ OpenConnect client PKCS ...
-      \__ OpenConnect client PKCS n
 
 OpenVPN CA: 
    \__ OpenVPN server cert

--- a/documentation/certificates.md
+++ b/documentation/certificates.md
@@ -2,24 +2,44 @@ Streisand PKI
 =============
 
 Streisand includes a role responsible for PKI certificate generation,
-separated into two distinct tasks:
+separated into three heirarchical tasks:
 
- - CA/Server
- - Client(s)
+```
+CA/Server
+   \__ CA Certificate
+     \__ Server certificate
+    \__ Client (1..n)
+      \__ Client PKCS (1..n)
+ 
+```
 
-The first will generate a certificate authority, and a server 
+CA/Server
+---------
+Guarded by `generate_ca_server: yes`
+
+Generate a certificate authority, and a server 
 certificate signed by the newly minted certificate authority.
 
-The latter task is responsible for generating client side certificates
-(using the same CA) used for authenticating connecting VPN clients.
+Client
+------
+Guarded by `generate_client: yes`
 
-Each VPN service that leverages the Streisand PKI generates its
-own CA/Server certificate and client certificates.
+Generate client side certificates using the same CA used for authenticating
+connecting VPN clients.
+
+Client PKCS
+-----------
+Guarded by `generate_pkcs: yes`
+
+Generate client PKCS files.
 
 Infrastructure
 --------------
 
-The overall PKI infrastructure assumes the following structure:
+Note: Each VPN service that invokes the certificates role will generate it's own 
+distinct public key infrastructure.
+
+The overall Streisand PKI infrastructure assumes the following structure:
 
 ```
 Web Root CA: 
@@ -30,6 +50,9 @@ OpenConnect CA:
    \__ OpenConnect client 1
    \__ OpenConnect client ...
    \__ OpenConnect client n
+      \__ OpenConnect client PKCS 1
+      \__ OpenConnect client PKCS ...
+      \__ OpenConnect client PKCS n
 
 OpenVPN CA: 
    \__ OpenVPN server cert
@@ -45,27 +68,16 @@ ISRG X1:
 Usage
 -----
 
-Utilizing the `certificates` role can be invoked as follows (using OpenVPN as an example):
-(If client certificates need to be generated, a directory for each client must be created
-first)
+The `certificates` role can be invoked as follows (using OpenVPN as an example, with variables expanded for brevity):
 
 ```
-- name: Create directories for clients # needed if client certificates are required
-  file:
-    path: "/etc/openvpn/{{ client_name.stdout }}"
-    state: directory
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-
 - include_role:
     name: certificates
   vars:
     ca_path:            "/etc/openvpn"
     tls_ca:             "/etc/openvpn/ca"
     tls_client_path:    "/etc/openvpn"
-    generate_ca_server: yes
+    generate_ca_server: yes 
     generate_client:    yes
     tls_request_subject:         "/C=US/ST=California/L=Beverly Hills/O=ACME CORPORATION/OU=Anvil Department"
     tls_server_common_name_file: "/etc/openvpn/openvpn-common-name.txt"
@@ -77,6 +89,7 @@ first)
 Note the following flags:
  - `generate_ca_server: yes`
  - `generate_client: yes`
+ - `generate_pkcs: yes`
 
  These must be made explicit, as the default value is `no`; certificates should not be generated unless
  they have to be.

--- a/playbooks/roles/certificates/defaults/main.yml
+++ b/playbooks/roles/certificates/defaults/main.yml
@@ -13,3 +13,4 @@ tls_key_size:     "4096"
 # include the certificates role
 generate_ca_server: no
 generate_client:    no
+generate_pkcs:      no

--- a/playbooks/roles/certificates/tasks/client.yml
+++ b/playbooks/roles/certificates/tasks/client.yml
@@ -1,4 +1,13 @@
 ---
+- name: Create directories for clients
+  file:
+    path: "{{ tls_client_path }}/{{ client_name.stdout }}"
+    state: directory
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
 - name: Generate the private keys for the client certificates
   command: openssl genrsa -out client.key {{ tls_key_size }}
   args:

--- a/playbooks/roles/certificates/tasks/main.yml
+++ b/playbooks/roles/certificates/tasks/main.yml
@@ -4,3 +4,6 @@
 
 - import_tasks: client.yml
   when: generate_client
+
+- import_tasks: pkcs.yml
+  when: generate_pkcs

--- a/playbooks/roles/certificates/tasks/pkcs.yml
+++ b/playbooks/roles/certificates/tasks/pkcs.yml
@@ -1,0 +1,42 @@
+---
+- name: "Generate a random password that will be used during the PKCS #12 conversion"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /-/g' > {{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password
+  args:
+    creates: "{{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
+- name: "Set permissions on the PKCS #12 password file"
+  file:
+    path: "{{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
+    owner: root
+    group: root
+    mode: 0600
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
+- name: "Register the PKCS #12 passwords"
+  command: cat {{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password
+  register: "vpn_client_pkcs12_password_list"
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+  changed_when: False
+
+- name: "Convert the keys and certificates into PKCS #12 format"
+  expect:
+    command: certtool --to-p12 --load-privkey {{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}/client.key --pkcs-cipher 3des-pkcs12 --load-certificate {{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}/client.crt --outfile {{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}.p12 --outder
+    responses:
+      "Enter a name for the key": "{{ vpn_client_password.client_name.stdout }}"
+      "Enter password":   "{{ vpn_client_password.stdout }}"
+      "Confirm password": "{{ vpn_client_password.stdout }}"
+    creates: "{{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}.p12"
+  with_items: "{{ vpn_client_pkcs12_password_list.results }}"
+  loop_control:
+    loop_var: "vpn_client_password"
+    label: "{{ vpn_client_password.client_name.item }}"

--- a/playbooks/roles/openconnect/tasks/docs.yml
+++ b/playbooks/roles/openconnect/tasks/docs.yml
@@ -16,7 +16,7 @@
   command: cp {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}.p12 {{ ocserv_gateway_location }}
   args:
     creates: "{{ ocserv_gateway_location }}/{{ ocserv_client_password.client_name.stdout }}.p12"
-  with_items: "{{ ocserv_client_pkcs12_password_list.results }}"
+  with_items: "{{ vpn_client_pkcs12_password_list.results }}"
   loop_control:
     loop_var: "ocserv_client_password"
     label: "{{ ocserv_client_password.client_name.item }}"

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -23,68 +23,19 @@
   args:
     creates: /etc/rc0.d/K20ocserv
 
-- name: Create directories for clients
-  file:
-    path: "{{ ocserv_path}}/{{ client_name.stdout }}"
-    state: directory
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-
 - include_role:
     name: certificates
   vars:
     ca_path:            "{{ ocserv_path }}"
     tls_ca:             "{{ ocserv_ca }}"
     tls_client_path:    "{{ ocserv_path }}"
+    vpn_name:           "ocserv"
     generate_ca_server: yes
     generate_client:    yes
+    generate_pkcs:      yes
     tls_server_common_name_file: "{{ ocserv_server_common_name_file }}"
     tls_sans:
       - "{{ streisand_ipv4_address }}"
-
-- name: "Generate a random password that will be used during the PKCS #12 conversion"
-  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /-/g' > {{ ocserv_path }}/ocserv-{{ client_name.stdout }}-pkcs12-password
-  args:
-    creates: "{{ ocserv_path }}/ocserv-{{ client_name.stdout }}-pkcs12-password"
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-
-- name: "Set permissions on the PKCS #12 password file"
-  file:
-    path: "{{ ocserv_path }}/ocserv-{{ client_name.stdout }}-pkcs12-password"
-    owner: root
-    group: root
-    mode: 0600
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-
-- name: "Register the PKCS #12 passwords"
-  command: cat {{ ocserv_path }}/ocserv-{{ client_name.stdout }}-pkcs12-password
-  register: "ocserv_client_pkcs12_password_list"
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-  changed_when: False
-
-- name: "Convert the keys and certificates into PKCS #12 format"
-  expect:
-    command: certtool --to-p12 --load-privkey {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}/client.key --pkcs-cipher 3des-pkcs12 --load-certificate {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}/client.crt --outfile {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}.p12 --outder
-    responses:
-      "Enter a name for the key": "{{ ocserv_client_password.client_name.stdout }}"
-      "Enter password":   "{{ ocserv_client_password.stdout }}"
-      "Confirm password": "{{ ocserv_client_password.stdout }}"
-    creates: "{{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}.p12"
-  with_items: "{{ ocserv_client_pkcs12_password_list.results }}"
-  loop_control:
-    loop_var: "ocserv_client_password"
-    label: "{{ ocserv_client_password.client_name.item }}"
 
 - name: Generate a random ocserv password
   shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 4 | xargs | sed -e 's/ /-/g' > {{ ocserv_password_file }}

--- a/playbooks/roles/openconnect/templates/instructions-fr.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions-fr.md.j2
@@ -20,7 +20,7 @@ Les certificats clients sont un mécanisme par lequel les clients peuvent s'auth
 1. Votre serveur OpenConnect émet son propre __certificat serveur__. Ceci est utilisé par le logiciel du client de votre appareil (tel que AnyConnect pour iOS) afin de  s'identifier de manière sécurisée avec le serveur VPN. Téléchargez le certificat de ce serveur.
    * [ca.crt](/openconnect/ca.crt)
 1. Chaque appareil que vous souhaitez configurer nécessite un __certificat client__ en plus du certificat serveur ci-dessus. Un certificat client est utilisé pour identifier et authentifier de manière sécurisée votre appareil sur le serveur VPN. Deux appareils ne peuvent pas utiliser le même certificat de client et être connectés simultanément (un certificat de client pour chaque appareil). Chaque certificat client est protégé par une mot de passe, qui sera nécessaire pour le déverrouiller une fois que vous l'importez dans votre appareil.
-{% for client in ocserv_client_pkcs12_password_list.results %}
+{% for client in vpn_client_pkcs12_password_list.results %}
    * [{{ client.client_name.stdout }}.p12](/openconnect/{{ client.client_name.stdout }}.p12), mot de passe: `{{ client.stdout }}` 
 {% endfor %}
 

--- a/playbooks/roles/openconnect/templates/instructions.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions.md.j2
@@ -20,7 +20,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 1. Your OpenConnect server issues its own __server certificate__. This is used by your device's client software (such as AnyConnect for iOS) to securely identify the VPN server. Download this server's certificate.
    * [ca.crt](/openconnect/ca.crt)
 1. Each device you wish to configure needs a __client certificate__ in addition to the server certificate above. A client certificate is used to securely identify and authenticate your device to the VPN server. Two devices can't use the same client certifcate and be logged in at the same time (one client certificate per device). Each client certificate is protected by a password, which will be needed to unlock it once you import it into your device.
-{% for client in ocserv_client_pkcs12_password_list.results %}
+{% for client in vpn_client_pkcs12_password_list.results %}
    * [{{ client.client_name.stdout }}.p12](/openconnect/{{ client.client_name.stdout }}.p12), password: `{{ client.stdout }}` 
 {% endfor %}
 

--- a/playbooks/roles/openvpn/tasks/main.yml
+++ b/playbooks/roles/openvpn/tasks/main.yml
@@ -8,15 +8,6 @@
     dest: /etc/dnsmasq.d/openvpn.conf
   notify: Restart dnsmasq
 
-- name: Create directories for clients
-  file:
-    path: "{{ openvpn_path}}/{{ client_name.stdout }}"
-    state: directory
-  with_items: "{{ vpn_client_names.results }}"
-  loop_control:
-    loop_var: "client_name"
-    label: "{{ client_name.item }}"
-
 - include_role:
     name: certificates
   vars:


### PR DESCRIPTION
This PR refactors the certificates role to do the following tasks: 
 - the underlying `client.yml` task is now responsible for generating client directories, reducing code duplication across the openvpn and ocserv roles
 - adds an additional task to generate client pkcs files, guarded by the `generate_pkcs` flag.
 - update and clean up the certificates documentation.