### PR TITLE
Clarify that not customizing will use site vars file.

### DIFF
--- a/streisand
+++ b/streisand
@@ -61,7 +61,9 @@ function validate() {
 function customize() {
   read -r -p "
 Do you wish to customize which services Streisand will install?
-Please enter the word 'yes' or hit enter to continue: " confirm
+By default Streisand will use the settings configured in $SITE_VARS
+
+Please enter the word 'yes' to customize or hit enter to continue: " confirm
   case "$confirm" in
     yes) echo; echo "Confirmed. Customizing Streisand services.";
          # NOTE(@cpu): We don't pass the other `--extra-vars` here because the


### PR DESCRIPTION
This commit updates the Streisand script's `customize` function to
clarify that if you do not enter "yes" the site vars file will be used.

Resolves https://github.com/StreisandEffect/streisand/issues/1039