### PR TITLE
Replace hardcoded simple-obfs commit with tag v0.0.4

### DIFF
--- a/playbooks/roles/shadowsocks/tasks/simple-obfs.yml
+++ b/playbooks/roles/shadowsocks/tasks/simple-obfs.yml
@@ -3,11 +3,7 @@
   git:
     repo: "https://github.com/shadowsocks/simple-obfs"
     dest: "{{ simple_obfs_compilation_directory }}"
-    version: "{{simple_obfs_version}}"
-    # NOTE(@cpu): this force can be removed once a release >0.0.3 of simple-obfs
-    # is cut. There is a cached git copy of aclocal.m4 that causes untracked
-    # changes in 0.0.3 fixed with 8c22d on simple-obfs master.
-    force: yes
+    version: "v{{simple_obfs_version}}"
 
 - name: Update the simple-obfs source code submodules
   command: git submodule update --init --recursive

--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -30,12 +30,7 @@ shadowsocks_location: "/etc/shadowsocks-libev"
 shadowsocks_password_file: "{{ shadowsocks_location }}/shadowsocks-password.txt"
 
 # simple-obfs vars
-# TODO(@cpu): Once a simple-obfs release > 0.0.3 has been cut we can switch back
-# to cloning a specific release instead of this commit that was the tip of
-# master at the time of writing. Presently 0.0.3 is the latest release and is
-# missing a segfault fix and retains udns support while we build
-# shadowsocks-libev with cares now
-simple_obfs_version: "2955a57624add482588b41fad68bbcd4c632fff5"
+simple_obfs_version: "0.0.4"
 simple_obfs_compilation_directory: "/usr/local/src/shadowsocks-simple-obfs-{{ simple_obfs_version }}"
 simple_obfs_configure_flags: "--disable-documentation"
 


### PR DESCRIPTION
The upstream shadowsocks simple-obfs project has cut a 0.0.4 release
that contains the bugfixes/work that we were relying on. This lets us
delete the hardcoded commit we were referencing as well as a workaround
for a bug in tree leaving the work dir dirty.