### PR TITLE
Use correct SSH keys metadata for GCE provisioning.

### DIFF
--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -18,7 +18,7 @@
     service_account_email: "{{ gce_service_account_email }}"
     image: "{{ gce_image }}"
     tags: "{{ gce_server_name }}"
-    metadata: '{"sshKeys":"root:{{ ssh_key.stdout }}"}'
+    metadata: '{"ssh-keys":"ubuntu:{{ ssh_key.stdout }}"}'
   register: streisand_server
 
 - name: Wait until the server has finished booting and OpenSSH is accepting connections


### PR DESCRIPTION
Per the GCE docs on SSH [metadata](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys):
> Note: Setting the sshKeys metadata value on project metadata is
> deprecated. Use the ssh-keys metadata value instead. If instances in
> your project uses older images, you might need to update the guest
> environments for these instances.

This commit updates the metadata key to be "ssh-keys" instead of
"sshKeys", fixing the problem where GCE provisioning required manual
intervention to fix SSH access.

Thanks to @vadimzharov for spotting the problem and providing the fix!!
I deleted all of the SSH keys and metadata on my GCE account and was
able to use this branch to provision a new instance without error where 
previously I had to attach an SSH key in the console manually.

Resolves https://github.com/StreisandEffect/streisand/issues/919