### PR TITLE
Avoid hardcoding LE subscriber agreement URL.

### DIFF
--- a/playbooks/roles/lets-encrypt/scripts/termsOfServiceLookup.py
+++ b/playbooks/roles/lets-encrypt/scripts/termsOfServiceLookup.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+termsOfServiceLookup.py fetches the terms-of-service URL from an ACME
+/directory URL. This can be used to avoid hardcoding the current
+terms-of-service URL somewhere and having to update it every time
+Let's Encrypt migrates to an updated ToS.
+
+@cpu - daniel@binaryparadox.net
+"""
+from __future__ import print_function
+
+import sys
+import urllib2
+import json
+
+
+def errorPrint(*args, **kwargs):
+    """
+    errorPrint prints to stderr and exits the script with a non-zero status
+    """
+    print(*args, file=sys.stderr, **kwargs)
+    sys.exit(1)
+
+
+def fetchDirectory(directoryURL):
+    """
+    fetchDirectory returns the JSON response from an ACME /directory URL
+    provided. If there is any kind of exception doing so the error is
+    printed to stderr and the script terminates with a non-zero exit code.
+    """
+    # HTTP GET the /directory URL
+    try:
+        resp = urllib2.urlopen(directoryURL)
+        directoryJSON = resp.read()
+    except Exception as e:
+        errorPrint("Unable to fetch ACME directory from '{0}': {1}"
+                   .format(directoryURL, e))
+    return directoryJSON
+
+
+def getTOSURL(directoryJSON):
+    """
+    getTOSURL returns the "terms-of-service" key from the /directory JSON's
+    "meta" key. If there is no "meta" key or no "terms-of-service" key then ""
+    is returned. If there is any kind of exception unmarshalling the directory
+    JSON the error is printed to stderr and the script terminates with
+    a non-zero exit code
+    """
+    # Unmarshal the /directory JSON to a dict
+    try:
+        directory = json.loads(directoryJSON)
+    except Exception as e:
+        errorPrint("Unable to unmarshal ACME directory JSON: {0}"
+                   .format(e))
+    return directory.get("meta", {}).get("terms-of-service", "")
+
+
+def getTOS(directoryURL):
+    """
+    getTOS prints the terms-of-service URL found in the ACME directory JSON
+    located at the provided directoryURL to stdout.
+    """
+    print(getTOSURL(fetchDirectory(directoryURL)))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: {0} [ACME /directory URL]".format(sys.argv[0]))
+        sys.exit(1)
+
+    getTOS(sys.argv[1])

--- a/playbooks/roles/lets-encrypt/scripts/termsOfServiceLookup.py
+++ b/playbooks/roles/lets-encrypt/scripts/termsOfServiceLookup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-termsOfServiceLookup.py fetches the terms-of-service URL from an ACME
+terms-of-service-lookup.py fetches the terms-of-service URL from an ACME
 /directory URL. This can be used to avoid hardcoding the current
 terms-of-service URL somewhere and having to update it every time
 Let's Encrypt migrates to an updated ToS.
@@ -14,33 +14,33 @@ import urllib2
 import json
 
 
-def errorPrint(*args, **kwargs):
+def error_print(*args, **kwargs):
     """
-    errorPrint prints to stderr and exits the script with a non-zero status
+    error_print prints to stderr and exits the script with a non-zero status
     """
     print(*args, file=sys.stderr, **kwargs)
     sys.exit(1)
 
 
-def fetchDirectory(directoryURL):
+def fetch_directory(directory_URL):
     """
-    fetchDirectory returns the JSON response from an ACME /directory URL
+    fetch_directory returns the JSON response from an ACME /directory URL
     provided. If there is any kind of exception doing so the error is
     printed to stderr and the script terminates with a non-zero exit code.
     """
     # HTTP GET the /directory URL
     try:
-        resp = urllib2.urlopen(directoryURL)
-        directoryJSON = resp.read()
+        resp = urllib2.urlopen(directory_URL)
+        directory_JSON = resp.read()
     except Exception as e:
-        errorPrint("Unable to fetch ACME directory from '{0}': {1}"
-                   .format(directoryURL, e))
-    return directoryJSON
+        error_print("Unable to fetch ACME directory from '{0}': {1}"
+                    .format(directory_URL, e))
+    return directory_JSON
 
 
-def getTOSURL(directoryJSON):
+def get_TOS_URL(directory_JSON):
     """
-    getTOSURL returns the "terms-of-service" key from the /directory JSON's
+    get_TOS_URL returns the "terms-of-service" key from the /directory JSON's
     "meta" key. If there is no "meta" key or no "terms-of-service" key then ""
     is returned. If there is any kind of exception unmarshalling the directory
     JSON the error is printed to stderr and the script terminates with
@@ -48,19 +48,19 @@ def getTOSURL(directoryJSON):
     """
     # Unmarshal the /directory JSON to a dict
     try:
-        directory = json.loads(directoryJSON)
+        directory = json.loads(directory_JSON)
     except Exception as e:
-        errorPrint("Unable to unmarshal ACME directory JSON: {0}"
-                   .format(e))
+        error_print("Unable to unmarshal ACME directory JSON: {0}"
+                    .format(e))
     return directory.get("meta", {}).get("terms-of-service", "")
 
 
-def getTOS(directoryURL):
+def get_TOS(directory_URL):
     """
-    getTOS prints the terms-of-service URL found in the ACME directory JSON
+    get_TOS prints the terms-of-service URL found in the ACME directory JSON
     located at the provided directoryURL to stdout.
     """
-    print(getTOSURL(fetchDirectory(directoryURL)))
+    print(get_TOS_URL(fetch_directory(directory_URL)))
 
 
 if __name__ == "__main__":
@@ -68,4 +68,4 @@ if __name__ == "__main__":
         print("Usage: {0} [ACME /directory URL]".format(sys.argv[0]))
         sys.exit(1)
 
-    getTOS(sys.argv[1])
+    get_TOS(sys.argv[1])

--- a/playbooks/roles/lets-encrypt/scripts/terms_of_service_lookup.py
+++ b/playbooks/roles/lets-encrypt/scripts/terms_of_service_lookup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-terms-of-service-lookup.py fetches the terms-of-service URL from an ACME
+terms_of_service_lookup.py fetches the terms-of-service URL from an ACME
 /directory URL. This can be used to avoid hardcoding the current
 terms-of-service URL somewhere and having to update it every time
 Let's Encrypt migrates to an updated ToS.

--- a/playbooks/roles/lets-encrypt/tasks/main.yml
+++ b/playbooks/roles/lets-encrypt/tasks/main.yml
@@ -6,6 +6,10 @@
     state: directory
     recurse: yes
 
+- name: Find the current Let's Encrypt subscriber agreement URL
+  script: "../scripts/termsOfServiceLookup.py {{ le_api_endpoint }}"
+  register: le_agreement
+
 - name: Put reponse file in place
   template:
     src: response.yaml.j2

--- a/playbooks/roles/lets-encrypt/tasks/main.yml
+++ b/playbooks/roles/lets-encrypt/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: Find the current Let's Encrypt subscriber agreement URL
   script: "../scripts/termsOfServiceLookup.py {{ le_api_endpoint }}"
   register: le_agreement
+  changed_when: False
 
 - name: Put reponse file in place
   template:

--- a/playbooks/roles/lets-encrypt/tasks/main.yml
+++ b/playbooks/roles/lets-encrypt/tasks/main.yml
@@ -7,7 +7,7 @@
     recurse: yes
 
 - name: Find the current Let's Encrypt subscriber agreement URL
-  script: "../scripts/termsOfServiceLookup.py {{ le_api_endpoint }}"
+  script: "../scripts/terms_of_service_lookup.py {{ le_api_endpoint }}"
   register: le_agreement
   changed_when: False
 

--- a/playbooks/roles/lets-encrypt/templates/response.yaml.j2
+++ b/playbooks/roles/lets-encrypt/templates/response.yaml.j2
@@ -1,5 +1,5 @@
 "acme-enter-email": "{{ streisand_admin_email }}"
-"acme-agreement:{{ le_agreements }}": true
+"acme-agreement:{{ le_agreement.stdout.strip() }}": true
 "acmetool-quickstart-choose-server": "{{ le_api_endpoint }}"
 "acmetool-quickstart-choose-method": redirector
 "acmetool-quickstart-complete": true

--- a/playbooks/roles/lets-encrypt/vars/main.yml
+++ b/playbooks/roles/lets-encrypt/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 le_base: /var/lib/acme
 le_port: 80
-le_agreements: "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"
 le_api_endpoint: "https://acme-v01.api.letsencrypt.org/directory"
 le_certificate: "{{ le_base }}/live/{{ streisand_domain }}/fullchain"
 le_private_key: "{{ le_base }}/live/{{ streisand_domain }}/privkey"


### PR DESCRIPTION
Prior to this commit the Let's Encrypt subscriber agreement URL required
for the [acmetool non-interactive response file](https://github.com/StreisandEffect/streisand/blob/bbd3f34094955f39828d0d104dd75e63f0e10497/playbooks/roles/lets-encrypt/templates/response.yaml.j2) was [hardcoded](https://github.com/StreisandEffect/streisand/blob/bbd3f34094955f39828d0d104dd75e63f0e10497/playbooks/roles/lets-encrypt/vars/main.yml#L4). This means
whenever Let's Encrypt changes their subscriber agreement URL the
lets-encrypt role will break until the agreement var is [updated to the
new value](https://github.com/StreisandEffect/streisand/commit/bbd3f34094955f39828d0d104dd75e63f0e10497).

Fortunately the ACME protocol specifies a way to learn the server's
current terms-of-service agreement URL. [Section 7.1.1 of draft-08](https://tools.ietf.org/html/draft-ietf-acme-acme-08#section-7.1.1) says:

    The object MAY additionally contain a field "meta".  If present, it
    MUST be a JSON object; each field in the object is an item of
    metadata relating to the service provided by the ACME server.

    The following metadata items are defined, all of which are OPTIONAL:

      "terms-of-service" (optional, string):  A URL identifying the current
        terms of service.

Let's Encrypt does send a "meta" element with a "terms-of-service" item.
This commit adds a small Python script that fetches the current
terms-of-service URL from the API directory for use in the acmetool
response file.

This will keep the response file current even if the agreement URL
changes.