### PR TITLE
lets-encrypt: Query Let's Encrypt for current agreement URL

### DIFF
--- a/playbooks/roles/lets-encrypt/tasks/main.yml
+++ b/playbooks/roles/lets-encrypt/tasks/main.yml
@@ -6,13 +6,13 @@
     state: directory
     recurse: yes
 
-- name: Query Let's Encrypt to find out the latest agreements
+- name: Query Let's Encrypt to find the current subscriber agreement URL
   uri:
     url: "{{ le_api_endpoint }}"
     body_format: json
   register: http_body
 
-- name: Extract Let's Encrypt agreements URL
+- name: Extract Let's Encrypt subscriber agreement URL
   set_fact:
     le_agreements: "{{ http_body['json']['meta']['terms-of-service'] }}"
 

--- a/playbooks/roles/lets-encrypt/tasks/main.yml
+++ b/playbooks/roles/lets-encrypt/tasks/main.yml
@@ -6,6 +6,16 @@
     state: directory
     recurse: yes
 
+- name: Query Let's Encrypt to find out the latest agreements
+  uri:
+    url: "{{ le_api_endpoint }}"
+    body_format: json
+  register: http_body
+
+- name: Extract Let's Encrypt agreements URL
+  set_fact:
+    le_agreements: "{{ http_body['json']['meta']['terms-of-service'] }}"
+
 - name: Put reponse file in place
   template:
     src: response.yaml.j2

--- a/playbooks/roles/lets-encrypt/vars/main.yml
+++ b/playbooks/roles/lets-encrypt/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 le_base: /var/lib/acme
 le_port: 80
-le_agreements: "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"
 le_api_endpoint: "https://acme-v01.api.letsencrypt.org/directory"
 le_certificate: "{{ le_base }}/live/{{ streisand_domain }}/fullchain"
 le_private_key: "{{ le_base }}/live/{{ streisand_domain }}/privkey"


### PR DESCRIPTION
As @cpu [pointed out](https://github.com/StreisandEffect/streisand/pull/1054#issue-275086994), there is an ACME API for querying the latest TOS. So we can actually fetch the TOS URL when running the playbook, instead of hardcoding it.