### PR TITLE
tests.sh: If $SITE is empty, don't include its --extra-vars clause.

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -23,10 +23,15 @@ function run_playbook {
     SITE="tests/site_vars/random.yml"
     "$DIR/randomize_sitevars.sh" "$SITE"
   fi
+  SITE_DECL=""
+  if [ -n "$SITE" ]; then
+    SITE_DECL="--extra-vars=@${SITE}"
+  fi
+
   ansible-playbook \
     -i "$DIR/inventory" \
     --extra-vars=@global_vars/vars.yml \
-    --extra-vars="@$SITE" \
+    $SITE_DECL \
     "$PLAYBOOK" "${EXTRA_FLAGS[@]}"
 }
 


### PR DESCRIPTION
In `tests/tests.sh`, the variable SITE may not be set in `run_playbook`. If it's not set, don't add a bare `--extra-vars=` to Ansible invocation.

Resolves https://github.com/StreisandEffect/streisand/issues/1052