### PR TITLE
Update shadowsocks-libev version to 3.1.1

### DIFF
--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -19,7 +19,7 @@ shadowsocks_dependencies:
   - rng-tools
   - libssl-dev
 
-shadowsocks_version: "3.1.0"
+shadowsocks_version: "3.1.1"
 shadowsocks_compilation_directory: "/usr/local/src/shadowsocks-libev-{{ shadowsocks_version }}"
 
 # Configuring the build without documentation means we save close to 900mb of deps


### PR DESCRIPTION
The upstream `shadowsocks-libev` project has [cut a 3.1.1 release](https://github.com/shadowsocks/shadowsocks-libev/releases/tag/v3.1.1). It
addresses a security vulnerability with `ss-manager`, and while
Streisand doesn't use this utility we should keep up-to-date regardless.