### PR TITLE
Fix openssl overriding default days to tls_days_valid from 30 days by…

### DIFF
--- a/playbooks/roles/certificates/tasks/ca-server.yml
+++ b/playbooks/roles/certificates/tasks/ca-server.yml
@@ -18,7 +18,7 @@
     mode: 0600
 
 - name: Generate CA certificate
-  command: openssl req -nodes -batch -new -x509 -key {{ tls_ca }}.key -out {{ tls_ca }}.crt -subj "{{ tls_request_subject }}/CN=ca-certificate"
+  command: openssl req -nodes -batch -new -x509 -key {{ tls_ca }}.key -days {{ tls_days_valid }} -out {{ tls_ca }}.crt -subj "{{ tls_request_subject }}/CN=ca-certificate"
   args:
     creates: "{{ tls_ca }}.crt"
 


### PR DESCRIPTION
After rewriting to centralized ca creation via openssl -days flag was forgotten.
Now it is used default 30 days
Version before rewriting
https://github.com/StreisandEffect/streisand/blob/c2e9b1e1c594630181f9fa037af0ae46c15c4d3c/playbooks/roles/openvpn/tasks/main.yml#L49