### PR TITLE
Generate multiple WireGuard client profiles.

### DIFF
--- a/playbooks/roles/wireguard/tasks/docs.yml
+++ b/playbooks/roles/wireguard/tasks/docs.yml
@@ -7,10 +7,14 @@
     mode: 0750
     state: directory
 
-- name: Copy the client configuration file to the WireGuard Gateway directory
-  command: cp {{ wireguard_path }}/wg0-client.conf {{ wireguard_gateway_location }}
+- name: Copy the client configuration files to the WireGuard Gateway directory
+  command: "cp {{ wireguard_client_path }}/{{ client_name.stdout }}/client.conf {{ wireguard_gateway_location }}/{{ client_name.stdout }}.client.conf"
   args:
-    creates: "{{ wireguard_gateway_location }}/wg0-client.conf"
+    creates: "{{ wireguard_gateway_location }}/{{ client_name.stdout }}.client.conf"
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
 
 - name: Generate the Markdown WireGuard instructions
   template:

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -3,41 +3,93 @@
 # Set up the PPA and install packages
 - import_tasks: install.yml
 
-- name: Generate private and public keys for the client and server
-  shell: umask 077; wg genkey | tee {{ item.private }} | wg pubkey > {{ item.public }}
+- name: Generate private and public key for the server
+  shell: "umask 077; wg genkey | tee {{ wireguard_server_private_key_file }} | wg pubkey > {{ wireguard_server_public_key_file }}"
   args:
-    creates: "{{ item.public }}"
-  with_items:
-    - { private: "{{ wireguard_server_private_key_file }}", public: "{{ wireguard_server_public_key_file }}" }
-    - { private: "{{ wireguard_client_private_key_file }}", public: "{{ wireguard_client_public_key_file }}" }
+    creates: "{{ wireguard_server_public_key_file }}"
 
-- name: Register the key file contents
+- name: Register the server key file contents
   command: cat {{ item }}
-  register: wireguard_key_files
+  register: wireguard_server_key_files
   changed_when: False
   with_items:
-    - "{{ wireguard_client_private_key_file }}"
-    - "{{ wireguard_client_public_key_file }}"
     - "{{ wireguard_server_private_key_file }}"
     - "{{ wireguard_server_public_key_file }}"
 
-- name: Set the key material facts
+- name: Set the server key material facts
   set_fact:
-    wireguard_client_private_key: "{{ wireguard_key_files.results[0].stdout }}"
-    wireguard_client_public_key:  "{{ wireguard_key_files.results[1].stdout }}"
-    wireguard_server_private_key: "{{ wireguard_key_files.results[2].stdout }}"
-    wireguard_server_public_key:  "{{ wireguard_key_files.results[3].stdout }}"
+    wireguard_server_private_key: "{{ wireguard_server_key_files.results[0].stdout }}"
+    wireguard_server_public_key:  "{{ wireguard_server_key_files.results[1].stdout }}"
 
-- name: Generate the client and server configuration files
-  template:
-    src: "{{ item }}.j2"
-    dest: "{{ wireguard_path }}/{{ item }}"
+- name: Create client directory
+  file:
+    path: "{{ wireguard_client_path }}"
+    state: directory
     owner: root
     group: root
     mode: 0600
-  with_items:
-    - wg0-client.conf
-    - wg0-server.conf
+
+- name: Create a directory for each client
+  file:
+    path: "{{ wireguard_client_path }}/{{ client_name.stdout }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0600
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
+- name: Generate private and public key for each client
+  shell: "umask 077; wg genkey | tee client.key | wg pubkey > client.pub"
+  args:
+    chdir: "{{ wireguard_client_path }}/{{ client_name.stdout }}"
+    creates: client.key
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
+- name: Register client public keys
+  command: cat client.pub
+  args:
+    chdir: "{{ wireguard_client_path }}/{{ client_name.stdout }}"
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+  register: wireguard_client_pubkeys
+  changed_when: False
+
+- name: Register client private keys
+  command: cat client.key
+  args:
+    chdir: "{{ wireguard_client_path }}/{{ client_name.stdout }}"
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+  register: wireguard_client_privkeys
+  changed_when: False
+
+- name: Generate the client configuration profiles
+  template:
+    src: client.conf.j2
+    dest: "{{ wireguard_client_path }}/{{ item[0].stdout }}/client.conf"
+  with_together:
+    - "{{ vpn_client_names.results }}"
+    - "{{ wireguard_client_privkeys.results }}"
+  loop_control:
+    label: "{{ item[0].item }}"
+
+- name: Generate the server configuration
+  template:
+    src: "server.conf.j2"
+    dest: "{{ wireguard_path }}/wg0-server.conf"
+    owner: root
+    group: root
+    mode: 0600
 
 # Set up the WireGuard firewall rules
 - import_tasks: firewall.yml

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -109,11 +109,13 @@
 
 # NOTE(@cpu): We don't use a `notify` to "Restart dnsmasq" here because it seems
 # that in some conditions Ansible mistakenly believes the dnsmasq restart can be
-# skipped
-- name: "Reload DNSMasq to pick up the new configuration"
+# skipped. We also don't use "reloaded" instead of "restarted" here because
+# dnsmasq doesn't seem to reload _new_ config files in that case, just existing
+# ones. A full restart is required in practice (sigh)
+- name: "Restart DNSMasq to pick up the new configuration"
   service:
     name: dnsmasq
-    state: reloaded
+    state: restarted
 
 # Generate Gateway documentation
 - import_tasks: docs.yml

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -109,7 +109,7 @@
 
 # NOTE(@cpu): We don't use a `notify` to "Restart dnsmasq" here because it seems
 # that in some conditions Ansible mistakenly believes the dnsmasq restart can be
-# skipped 
+# skipped
 - name: "Reload DNSMasq to pick up the new configuration"
   service:
     name: dnsmasq

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -106,7 +106,14 @@
   template:
     src: wireguard_dnsmasq.conf.j2
     dest: /etc/dnsmasq.d/wireguard.conf
-  notify: Restart dnsmasq
+
+# NOTE(@cpu): We don't use a `notify` to "Restart dnsmasq" here because it seems
+# that in some conditions Ansible mistakenly believes the dnsmasq restart can be
+# skipped 
+- name: "Reload DNSMasq to pick up the new configuration"
+  service:
+    name: dnsmasq
+    state: reloaded
 
 # Generate Gateway documentation
 - import_tasks: docs.yml

--- a/playbooks/roles/wireguard/templates/client.conf.j2
+++ b/playbooks/roles/wireguard/templates/client.conf.j2
@@ -1,5 +1,6 @@
+# "{{ item[0].stdout }}" - Streisand WireGuard Client Profile
 [Interface]
-Address = 10.192.122.2/32
+Address = 10.192.122.{{ (item[0].item|int) + 1 }}/32
 # The use of DNS below effectively expands to:
 #   PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a tun.%i -m 0 -x
 #   PostDown = resolvconf -d tun.%i
@@ -8,7 +9,7 @@ Address = 10.192.122.2/32
 # The IP address of the DNS server that is available via the encrypted
 # WireGuard interface is {{ dnsmasq_wireguard_ip }}.
 DNS = {{ dnsmasq_wireguard_ip }}
-PrivateKey = {{ wireguard_client_private_key }}
+PrivateKey = {{ item[1].stdout }}
 
 [Peer]
 PublicKey = {{ wireguard_server_public_key }}

--- a/playbooks/roles/wireguard/templates/instructions-fr.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions-fr.md.j2
@@ -10,8 +10,13 @@ WireGuard n'est actuellement disponible que pour Linux, mais support [multi-plat
 <a name="linux"></a>
 ### Linux ###
 1. [Installer WireGuard](https://www.wireguard.com/install/)
-1. Téléchargez le fichier de configuration du client:
-   * [wg0-client.conf](/wireguard/wg0-client.conf)
+1. Téléchargez un fichier de configuration du client. **Un seul ordi peut utiliser un profil à la fois**. Pour cet exemple, nous supposerons que vous avez téléchargéz le fichier {{ vpn_client_names.results[0].stdout }}:
+{% for client in vpn_client_names.results %}
+   * [{{ client.stdout }}](/wireguard/{{ client.stdout }}.client.conf)
+{% endfor %}
+1. Renommez le fichier:
+
+  `mv ~/Downloads/{{ vpn_client_names.results[0].stdout }}.client.conf ~/Downloads/wg0-client.conf`
 1. Définir les autorisations sur le fichier de configuration du client:
 
    `sudo chown -v root:root ~/Downloads/wg0-client.conf; sudo chmod -v 600 ~/Downloads/wg0-client.conf`
@@ -28,4 +33,4 @@ WireGuard n'est actuellement disponible que pour Linux, mais support [multi-plat
    `sudo wg-quick down wg0-client`
 
 #### Une note sur la configuration DNS ####
-Le fichier `wg0-client.conf` inlcure la commande `DNS` qui utilise `resolvconf` afin de diriger le trafic DNS vers le serveur dnsmasq qui est disponible via l'interface cryptée WireGuard à `{{ dnsmasq_wireguard_ip }}`. Bien que `resolvconf` soit un utilitaire commun, vous devrez peut-être remplacer cette ligne avec `PostUp`/`PostDown` pour votre distribution ou votre configuration réseau particulière.
+Chaque fichier inclure la commande `DNS` qui utilise `resolvconf` afin de diriger le trafic DNS vers le serveur dnsmasq qui est disponible via l'interface cryptée WireGuard à `{{ dnsmasq_wireguard_ip }}`. Bien que `resolvconf` soit un utilitaire commun, vous devrez peut-être remplacer cette ligne avec `PostUp`/`PostDown` pour votre distribution ou votre configuration réseau particulière.

--- a/playbooks/roles/wireguard/templates/instructions-fr.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions-fr.md.j2
@@ -10,7 +10,7 @@ WireGuard n'est actuellement disponible que pour Linux, mais support [multi-plat
 <a name="linux"></a>
 ### Linux ###
 1. [Installer WireGuard](https://www.wireguard.com/install/)
-1. Téléchargez un fichier de configuration du client. **Un seul ordi peut utiliser un profil à la fois**. Pour cet exemple, nous supposerons que vous avez téléchargéz le fichier {{ vpn_client_names.results[0].stdout }}:
+1. Téléchargez un fichier de configuration client. **Un seul ordinateur peut utiliser un profil à la fois**. Pour cet exemple, nous supposerons que vous avez téléchargé le fichier {{ vpn_client_names.results[0].stdout }}:
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/wireguard/{{ client.stdout }}.client.conf)
 {% endfor %}

--- a/playbooks/roles/wireguard/templates/instructions.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions.md.j2
@@ -10,8 +10,13 @@ WireGuard is currently only available for Linux, but [cross-platform](https://ww
 <a name="linux"></a>
 ### Linux ###
 1. [Install WireGuard](https://www.wireguard.com/install/)
-1. Download the client configuration file:
-   * [wg0-client.conf](/wireguard/wg0-client.conf)
+1. Download one of the client configuration files. **Only one computer can use a profile at a time**. For this example we'll assume you downloaded {{ vpn_client_names.results[0].stdout }}:
+{% for client in vpn_client_names.results %}
+   * [{{ client.stdout }}](/wireguard/{{ client.stdout }}.client.conf)
+{% endfor %}
+1. Rename the downloaded client configuration:
+
+  `mv ~/Downloads/{{ vpn_client_names.results[0].stdout }}.client.conf ~/Downloads/wg0-client.conf`
 1. Set permissions on the client configuration file:
 
    `sudo chown -v root:root ~/Downloads/wg0-client.conf; sudo chmod -v 600 ~/Downloads/wg0-client.conf`
@@ -32,4 +37,4 @@ WireGuard is currently only available for Linux, but [cross-platform](https://ww
    `sudo wg-quick down wg0-client`
 
 #### A note on DNS configuration ####
-The `wg0-client.conf` file includes a `DNS` command that uses resolvconf to direct DNS traffic to the dnsmasq server that is available via the WireGuard encrypted interface at `{{ dnsmasq_wireguard_ip }}`. Although resolvconf is a common utility, you may need to use `PostUp`/`PostDown` with a different command for your distribution or particular network configuration.
+Each client configuration profile includes a `DNS` command that uses resolvconf to direct DNS traffic to the dnsmasq server that is available via the WireGuard encrypted interface at `{{ dnsmasq_wireguard_ip }}`. Although resolvconf is a common utility, you may need to use `PostUp`/`PostDown` with a different command for your distribution or particular network configuration.

--- a/playbooks/roles/wireguard/templates/server.conf.j2
+++ b/playbooks/roles/wireguard/templates/server.conf.j2
@@ -1,0 +1,13 @@
+[Interface]
+Address = 10.192.122.1/24
+SaveConfig = true
+ListenPort = {{ wireguard_port }}
+PrivateKey = {{ wireguard_server_private_key }}
+
+{% for client in vpn_client_names.results %}
+# "{{ client.stdout }}" Client Peer
+[Peer]
+PublicKey = {{ wireguard_client_pubkeys.results[(client.item|int)-1].stdout }}
+AllowedIPs = 10.192.122.{{ (client.item|int)+1 }}/32
+
+{% endfor %}

--- a/playbooks/roles/wireguard/templates/wg0-server.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-server.conf.j2
@@ -1,9 +1,0 @@
-[Interface]
-Address = 10.192.122.1/24
-SaveConfig = true
-ListenPort = {{ wireguard_port }}
-PrivateKey = {{ wireguard_server_private_key }}
-
-[Peer]
-PublicKey = {{ wireguard_client_public_key }}
-AllowedIPs = 10.192.122.2/32

--- a/playbooks/roles/wireguard/vars/main.yml
+++ b/playbooks/roles/wireguard/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 wireguard_path: "/etc/wireguard"
-wireguard_client_private_key_file: "{{ wireguard_path }}/client.key"
-wireguard_client_public_key_file:  "{{ wireguard_path }}/client.pub"
+wireguard_client_path: "{{ wireguard_path }}/clients"
+
 wireguard_server_private_key_file: "{{ wireguard_path }}/server.key"
 wireguard_server_public_key_file:  "{{ wireguard_path }}/server.pub"
 


### PR DESCRIPTION
This commit updates the WireGuard playbook to follow the client
generation approach used by the OpenVPN playbook. This means using the
BIP-0039 randomly generated client names & honouring the `vpn_clients`
var to determine how many client profiles to make. Like OpenVPN only one
client profile may be in use at a time.

I added un peu de mauvais français to keep the translations ~= in-sync.
Forgive my Franglais.

Thanks to @alimakki for helping me figure out some of the templating :-)

Resolves https://github.com/StreisandEffect/streisand/issues/693