### PR TITLE
Update Simple-Obfs version to 0.0.5

### DIFF
--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -30,7 +30,7 @@ shadowsocks_location: "/etc/shadowsocks-libev"
 shadowsocks_password_file: "{{ shadowsocks_location }}/shadowsocks-password.txt"
 
 # simple-obfs vars
-simple_obfs_version: "0.0.4"
+simple_obfs_version: "0.0.5"
 simple_obfs_compilation_directory: "/usr/local/src/shadowsocks-simple-obfs-{{ simple_obfs_version }}"
 simple_obfs_configure_flags: "--disable-documentation"
 


### PR DESCRIPTION
The [upstream](https://github.com/shadowsocks/simple-obfs) project has released an updated version of `Simple-Obfs` plugin. [Changelog](https://github.com/shadowsocks/simple-obfs/blob/master/Changes) mentions a fix for building on windows. 