### PR TITLE
tests.sh: use the main Ansible playbook as well

### DIFF
--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 nocows = 1
-roles_path = playbooks/roles/
+roles_path = playbooks/roles:../playbooks/roles
 host_key_checking = False
 remote_tmp = $HOME/.ansible/tmp
 local_tmp = $HOME/.ansible/tmp


### PR DESCRIPTION
`tests/tests.sh syntax` blows up because it can't import modules from the primary playbook directory.