### PR TITLE
Don't turn on HTTP Strict Transport Security on non-LE servers

### DIFF
--- a/playbooks/roles/streisand-gateway/templates/vhost.j2
+++ b/playbooks/roles/streisand-gateway/templates/vhost.j2
@@ -32,7 +32,6 @@ server {
   ssl_session_tickets off;
 
   # headers
-
   add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection "1; mode=block";

--- a/playbooks/roles/streisand-gateway/templates/vhost.j2
+++ b/playbooks/roles/streisand-gateway/templates/vhost.j2
@@ -11,6 +11,9 @@ server {
   # resolver
   resolver {{ upstream_dns_servers | join(' ') }} valid=300s;
   resolver_timeout 5s;
+  # It'd be great to include HSTS in non-LE installs too, but
+  # HSTS diables "clicking through" the HTTPS error pages.
+  add_header Strict-Transport-Security max-age=63072000;
 {% else %}
   ssl_certificate      {{ nginx_self_signed_certificate }};
   ssl_certificate_key  {{ nginx_private_key }};
@@ -29,7 +32,7 @@ server {
   ssl_session_tickets off;
 
   # headers
-  add_header Strict-Transport-Security max-age=63072000;
+
   add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
Like it or not, a lot of people depend on being able to click through the "this cert sucks" page on non-LE servers. HSTS prohibits click-throughs. Perhaps "lots of people depend" is a little strong, but there are going to be people who get stuck on this step.