### PR TITLE
Added autoindexing for the openvpn directories

### DIFF
--- a/playbooks/roles/streisand-gateway/templates/vhost.j2
+++ b/playbooks/roles/streisand-gateway/templates/vhost.j2
@@ -48,6 +48,10 @@ server {
   location / {
     autoindex off; 
   }
+  
+  location /openvpn/ {
+    autoindex on;
+  }
 
   location /monit/ {
     rewrite ^/monit/(.*) /$1 break;


### PR DESCRIPTION
Commit 811bea1 broke listing .crt and .key files for openvpn directories as it now appears with a 403 error. 

I added a bit to allow auto indexing on openvpn.