### PR TITLE
Direct link to NetworkManager OpenVPN files.

### DIFF
--- a/playbooks/roles/openvpn/templates/instructions-fr.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions-fr.md.j2
@@ -88,9 +88,13 @@ Pour des raisons de sécurité, les clients OpenVPN généralement ont leurs pro
 ### Linux (Ubuntu) ###
 Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour NetworkManager. Cela vous donne une jolie petite interface pour la connexion, et il gère correctement les modifications DNS nécessaires lors de la connexion / déconnexion. Malheureusement, le plugin ne prend pas en charge les profils .ovpn, de sorte que la liste des étapes est un peu plus impliquée.
 
-1. Premièrement, téléchargez tous les fichiers .crt et .key de l'un de ces répertoires:
+1. Premièrement, téléchargez le OpenVPN CA Certificate, le certificate `.crt` fichier, la clé privée `.key` fichier, et la TLS authentication clé `ta.key` fichier pour l'un ces profils en dessous:
 {% for client in vpn_client_names.results %}
-   * [{{ client.stdout }}](/openvpn/{{ client.stdout }})
+   * {{ client.stdout }}
+      * CA Cert: [ca.crt](/openvpn/{{ client.stdout }}/ca.crt)
+      * Client Cert: [{{ client.stdout }}.crt](/openvpn/{{ client.stdout }}/client.crt)
+      * Client Clé: [{{ client.stdout }}.key](/openvpn/{{ client.stdout }}/client.key)
+      * TA Clé: [ta.key](/openvpn/{{ client.stdout }}/ta.key)
 {% endfor %}
 1. Installez le plugin OpenVPN pour NetworkManager.
 
@@ -103,9 +107,9 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
 1. Saisissez `{{ streisand_server_name }}` pour la *Nom de la connexion*.
 1. Saisissez `{{ openvpn_server }}` pour le *Gateway*.
 1. Assurez-vous que *Certificates (TLS)* est sélectionné pour le *Type*.
-1. Sélectionnez `client.crt` dans le répertoire des fichiers clients de votre choix pour le *User Certificate*.
-1. Sélectionnez `ca.crt` à partir du même répertoire de fichiers clients pour le *CA Certificate*.
-1. Sélectionnez `client.key` dans le même répertoire de fichiers clients pour le *Private Key*.
+1. Sélectionnez le `client.crt` fichier de votre choix pour le *User Certificate*.
+1. Sélectionnez le `ca.crt` fichier pour le *CA Certificate*.
+1. Sélectionnez le `client.key` ficher pour le *Private Key*.
 1. Cliquez le bouton *Advanced*.
 1. Accédez à l'onglet *General*.
    * Vérifier *Use custom gateway port* et entrer `{{openvpn_port}}` comme sa valeur.
@@ -121,7 +125,7 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
    * Dans le menu déroulant *Server Certificate Check* selectionnez `verify name exactly` et saisissez `{{ openvpn_server_common_name.stdout }}` pour sa valeur.
    * Cocher *Verify peer (server) certificate usage signature*.
    * Cocher *Use additional TLS authentication*.
-     * Sélectionnez la `ta.key` à partir du répertoire client-fichiers pour le *Key File*.
+     * Sélectionnez le `ta.key` fichier pour le *Key File*.
      * Sélectionnez `1` pour la *Key Direction*.
    * Cliquez *Valider*.
 1. Cliquez *Enregistrer*

--- a/playbooks/roles/openvpn/templates/instructions-fr.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions-fr.md.j2
@@ -88,7 +88,7 @@ Pour des raisons de sécurité, les clients OpenVPN généralement ont leurs pro
 ### Linux (Ubuntu) ###
 Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour NetworkManager. Cela vous donne une jolie petite interface pour la connexion, et il gère correctement les modifications DNS nécessaires lors de la connexion / déconnexion. Malheureusement, le plugin ne prend pas en charge les profils .ovpn, de sorte que la liste des étapes est un peu plus impliquée.
 
-1. Premièrement, téléchargez le OpenVPN CA Certificate, le certificate `.crt` fichier, la clé privée `.key` fichier, et la TLS authentication clé `ta.key` fichier pour l'un ces profils en dessous:
+1. Premièrement, téléchargez le certificat CA d'OpenVPN, le certificat client `.crt`, la clé privée du client `.key`, et finalement la clé d'authentification TLS `ta.key` pour l'un ces profils en dessous:
 {% for client in vpn_client_names.results %}
    * {{ client.stdout }}
       * CA Cert: [ca.crt](/openvpn/{{ client.stdout }}/ca.crt)
@@ -107,9 +107,9 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
 1. Saisissez `{{ streisand_server_name }}` pour la *Nom de la connexion*.
 1. Saisissez `{{ openvpn_server }}` pour le *Gateway*.
 1. Assurez-vous que *Certificates (TLS)* est sélectionné pour le *Type*.
-1. Sélectionnez le `client.crt` fichier de votre choix pour le *User Certificate*.
-1. Sélectionnez le `ca.crt` fichier pour le *CA Certificate*.
-1. Sélectionnez le `client.key` ficher pour le *Private Key*.
+1. Sélectionnez le fichier `client.crt` de votre choix pour le *User Certificate*.
+1. Sélectionnez le fichier `ca.crt` pour le *CA Certificate*.
+1. Sélectionnez le ficher `client.key` pour le *Private Key*.
 1. Cliquez le bouton *Advanced*.
 1. Accédez à l'onglet *General*.
    * Vérifier *Use custom gateway port* et entrer `{{openvpn_port}}` comme sa valeur.
@@ -125,7 +125,7 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
    * Dans le menu déroulant *Server Certificate Check* selectionnez `verify name exactly` et saisissez `{{ openvpn_server_common_name.stdout }}` pour sa valeur.
    * Cocher *Verify peer (server) certificate usage signature*.
    * Cocher *Use additional TLS authentication*.
-     * Sélectionnez le `ta.key` fichier pour le *Key File*.
+     * Sélectionnez le fichier `ta.key` pour le *Key File*.
      * Sélectionnez `1` pour la *Key Direction*.
    * Cliquez *Valider*.
 1. Cliquez *Enregistrer*

--- a/playbooks/roles/openvpn/templates/instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions.md.j2
@@ -88,9 +88,13 @@ For security reasons, OpenVPN clients typically have their own unique certificat
 ### Linux (Ubuntu) ###
 It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager. This gives you a nice little interface for connecting, and it properly handles the necessary DNS changes when you connect/disconnect. Unfortunately, the plugin does not support .ovpn profiles, so the list of steps is a little more involved.
 
-1. First, download all of the .crt and .key files from one of these directories:
+1. First, download the OpenVPN CA certificate, the certificate `.crt` file, private key `.key` file, and TLS authentication key `ta.key` file for one of the client profiles below:
 {% for client in vpn_client_names.results %}
-   * [{{ client.stdout }}](/openvpn/{{ client.stdout }})
+   * {{ client.stdout }}
+      * CA Cert: [ca.crt](/openvpn/{{ client.stdout }}/ca.crt)
+      * Client Cert: [{{ client.stdout }}.crt](/openvpn/{{ client.stdout }}/client.crt)
+      * Client Key: [{{ client.stdout }}.key](/openvpn/{{ client.stdout }}/client.key)
+      * TA key: [ta.key](/openvpn/{{ client.stdout }}/ta.key)
 {% endfor %}
 1. Install the OpenVPN plugin for NetworkManager.
 
@@ -103,9 +107,9 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
 1. Enter `{{ streisand_server_name }}` for the *Connection name*.
 1. Enter `{{ openvpn_server }}` for the *Gateway*.
 1. Make sure *Certificates (TLS)* is selected for the *Type*.
-1. Select `client.crt` from the client-files directory of your choice for the *User Certificate*.
-1. Select `ca.crt` from the same client-files directory for the *CA Certificate*.
-1. Select `client.key` from the same client-files directory for the *Private Key*.
+1. Select the `client.crt` file you downloaded for the *User Certificate*.
+1. Select the `ca.crt` file you downloaded for the *CA Certificate*.
+1. Select the `client.key` file you downloaded for the *Private Key*.
 1. Click the *Advanced* button.
 1. Go to the *General* tab.
    * Check *Use custom gateway port* and enter `{{ openvpn_port }}` as its value.
@@ -121,7 +125,7 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
    * Under *Server Certificate Check* choose `verify name exactly` and enter `{{ openvpn_server_common_name.stdout }}` as its value.
    * Check *Verify peer (server) certificate usage signature*.
    * Check *Use additional TLS authentication*.
-     * Select the `ta.key` from the client-files directory for the *Key File*.
+     * Select the `ta.key` file you downloaded from the client-files directory for the *Key File*.
      * Select `1` as the *Key Direction*.
    * Click *OK*.
 1. Click *Save...*


### PR DESCRIPTION
Previous to this commit the "Linux (Ubuntu)" NetworkManager instructions
for configuring OpenVPN with a client profile instructed users to
download several files from a raw directory index. This broke in 811bea1
when we added `autoindex off;` to the nginx config.

This commit updates the OpenVPN instructions template (for EN and FR) to
directly link to each of the required files instead of relying on the
directory index. This is a better user experience overall, directory
indexes are ugly!

My FR updates are probably très mauvais. Je suis désolé!! :-x

Thanks to @Spengreb  for flagging the issue initially in https://github.com/StreisandEffect/streisand/pull/1075