### PR TITLE
Centralize Python requirements in a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,28 @@
+# Install Streisand requirements with:
+#
+#   pip install -r ./requirements.txt
+#
+# If you have problems running this, try the util/venv-builder.sh script.
+
+# Core
+ansible
+
+# AWS
+boto
+boto3
+
+# Azure
+ansible[azure]
+
+# Digital Ocean
+packaging
+dopy==0.3.5
+
+# Google Compute Engine
+apache-libcloud>=1.5.0
+
+# Linode
+linode-python
+
+# Rackspace
+pyrax

--- a/util/venv-dependencies.sh
+++ b/util/venv-dependencies.sh
@@ -183,26 +183,8 @@ our_pip_install --upgrade pip
 # The pip we want should be in our path now. Make sure we use it.
 hash -r
 
-our_pip_install ansible
-
-# Python dependencies for various providers. Note that
-# "ansible[azure]" means "install ansible, and add additional
-# dependencies packages from ansible's 'azure' set. Since ansible is
-# already installed (see above), this just means "Azure dependencies".
-
-packages="$(cat <<EOF
-boto boto3
-ansible[azure]
-dopy==0.3.5
-apache-libcloud>=1.5.0 pycrypto
-linode-python
-pyrax
-EOF
-)"
-
-# We want word splitting.
-# shellcheck disable=SC2059,SC2086
-our_pip_install $packages
+# Now we can install all the Python modules.
+our_pip_install -r requirements.txt
 
 echo "
 *************


### PR DESCRIPTION
Currently we keep track of which Python packages are needed in several different places. I generally consider the README to be definitive. But the README isn't machine-readable.

This adds a `requirements.txt` listing all Python dependencies. I've been stalling on README updates, but it'd be cool if the easy instruction were "install pip, then `pip install -r requirements.txt`. There's always virtualenvs if people run into dependency problems--but venv-builder needs to be put in the README too.

I can do the README mods either in this PR or another one.