### PR TITLE
Clarify that SSLH OpenVPN profiles are for port 443.

### DIFF
--- a/playbooks/roles/openvpn/templates/instructions-fr.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions-fr.md.j2
@@ -31,7 +31,7 @@ Pour des raisons de sécurité, les clients OpenVPN généralement ont leurs pro
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
 {% endfor %}
-   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui ne permet l'accès aux ports `80` et` 443`.*
+   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui ne permet l'accès aux port `443`.*
    * *[Profils UDP](#udp-profiles) sont disponibles.*
    * *[Profils combinés](#combined-profiles) sont maintenant disponibles.*
 1. Ouvrez le directoire *config* situé dans le dossier de destination. Pour la plupart des utilisateurs, ça sera *C:\Programmes\OpenVPN\config* ou *C:\Program Files (x86)\OpenVPN\config*. Vous verrez un seul fichier README dans ce répertoire.
@@ -50,7 +50,7 @@ Pour des raisons de sécurité, les clients OpenVPN généralement ont leurs pro
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
 {% endfor %}
-   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui ne permet l'accès aux ports `80` et` 443`.*
+   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui ne permet l'accès aux port `443`.*
    * *[Profils UDP](#udp-profiles) sont disponibles.*
    * *[Profils combinés](#combined-profiles) sont maintenant disponibles.*
 1. Double-cliquez le profile OpenVPN.
@@ -69,7 +69,7 @@ Pour des raisons de sécurité, les clients OpenVPN généralement ont leurs pro
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
 {% endfor %}
-   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui permet uniquement l'accès aux ports `80` et` 443`.*
+   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui permet uniquement l'accès aux port `443`.*
    * *[Profils UDP](#udp-profiles) sont disponibles.*
    * *[Profils combinés](#combined-profiles) sont maintenant disponibles.*
 1. Copiez le fichier `{{ openvpn_direct_profile_filename }}` téléchargé vers l'emplacement de votre choix. */etc/openvpn/* est une bonne option.
@@ -113,7 +113,7 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
 1. Cliquez le bouton *Advanced*.
 1. Accédez à l'onglet *General*.
    * Vérifier *Use custom gateway port* et entrer `{{openvpn_port}}` comme sa valeur.
-     * Port `443` est disponible en alternative si vous êtes sur un réseau qui ne permet l'accès aux deux ports HTTP standard.
+     * Port `443` est disponible en alternative si vous êtes sur un réseau qui ne permet l'accès aux le port HTTPS standard.
      * Vous pouvez également utiliser le port `{{ openvpn_port_udp }}` pour une connexion UDP.
      * Le profil combiné qui parcourt le port UDP `{{ openvpn_port_udp }}`, le port TCP `{{ openvpn_port }}`et `{{ openvpn_port_sslh }}` est également disponible.
    * Cocher *Use LZO data compression*.
@@ -139,7 +139,7 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
 {% endfor %}
-   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui permet uniquement l'accès aux ports `80` et` 443`.*
+   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui permet uniquement l'accès aux port `443`.*
    * *[Profils UDP](#udp-profiles) sont disponibles.*
    * *[Profils combinés](#combined-profiles) sont maintenant disponibles.*
 1. Copiez le fichier `{{ openvpn_direct_profile_filename }}` sur votre téléphone.
@@ -158,7 +158,7 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
 {% endfor %}
-   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui permet uniquement l'accès aux ports `80` et` 443`.*
+   * *[Profils alternatifs](#sslh-profiles) sont disponibles si vous êtes sur un réseau qui permet uniquement l'accès aux port `443`.*
    * *[Profils UDP](#udp-profiles) sont disponibles.*
    * *[Profils combinés](#combined-profiles) sont maintenant disponibles.*
 1. Ouvrez iTunes sur votre ordinateur et connectez votre téléphone.

--- a/playbooks/roles/openvpn/templates/instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions.md.j2
@@ -31,7 +31,7 @@ For security reasons, OpenVPN clients typically have their own unique certificat
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
 {% endfor %}
-   * *[Alternate profiles](#sslh-profiles) are available if you are on a network that only allows access to ports `80` and `443`.*
+   * *[Alternate profiles](#sslh-profiles) are available if you are on a network that only allows access to port `443`.*
    * *[UDP profiles](#udp-profiles) available.*
    * *[Combined profiles](#combined-profiles) are now available.*
 1. Open the *config* directory that is located in the Destination Folder. For most users, this will either be in *C:\Program Files\OpenVPN\config* or *C:\Program Files (x86)\OpenVPN\config*. You will see a single README file in this directory.
@@ -50,7 +50,7 @@ For security reasons, OpenVPN clients typically have their own unique certificat
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
 {% endfor %}
-   * *[Alternate profiles](#sslh-profiles) are available if you are on a network that only allows access to ports `80` and `443`.*
+   * *[Alternate profiles](#sslh-profiles) are available if you are on a network that only allows access to port `443`.*
    * *[UDP profiles](#udp-profiles) available.*
    * *[Combined profiles](#combined-profiles) are now available.*
 1. Double-click the OpenVPN profile.
@@ -69,7 +69,7 @@ For security reasons, OpenVPN clients typically have their own unique certificat
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
 {% endfor %}
-   * *[Alternate profiles](#sslh-profiles) are available if you are on a network that only allows access to ports `80` and `443`.*
+   * *[Alternate profiles](#sslh-profiles) are available if you are on a network that only allows access to port `443`.*
    * *[UDP profiles](#udp-profiles) available.*
    * *[Combined profiles](#combined-profiles) are now available.*
 1. Copy the downloaded `{{ openvpn_direct_profile_filename }}` file to the location of your choice. */etc/openvpn/* is a decent option.
@@ -113,7 +113,7 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
 1. Click the *Advanced* button.
 1. Go to the *General* tab.
    * Check *Use custom gateway port* and enter `{{ openvpn_port }}` as its value.
-     * Port `443` is available as an alternative if you are on a network that only allows access to the two standard HTTP ports.
+     * Port `443` is available as an alternative if you are on a network that only allows access to the standard HTTPS port.
      * You can also use port `{{ openvpn_port_udp }}` for a UDP connection.
      * A combined profile which cycles through UDP port `{{ openvpn_port_udp }}`, TCP port `{{ openvpn_port }}` and `{{ openvpn_port_sslh }}` is also available.
    * Check *Use LZO data compression*.


### PR DESCRIPTION
We do not generate any profiles that would mimick HTTP on port 80, only
HTTPS on 443.

Resolves #1074