### PR TITLE
Revert "Switch to BIP identifiers/password generation"

### DIFF
--- a/playbooks/roles/certificates/tasks/ca-server.yml
+++ b/playbooks/roles/certificates/tasks/ca-server.yml
@@ -23,7 +23,7 @@
     creates: "{{ tls_ca }}.crt"
 
 - name: Generate a random server common name
-  shell: "{{ streisand_word_gen.long_identifier }} > {{ tls_server_common_name_file }}"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /./g' | cut -c 1-64 > {{ tls_server_common_name_file }}
   args:
     creates: "{{ tls_server_common_name_file }}"
 

--- a/playbooks/roles/certificates/tasks/pkcs.yml
+++ b/playbooks/roles/certificates/tasks/pkcs.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Generate a random password that will be used during the PKCS #12 conversion"
-  shell: "{{ streisand_word_gen.weak_password }} > {{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /-/g' > {{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password
   args:
     creates: "{{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
   with_items: "{{ vpn_client_names.results }}"

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -38,7 +38,7 @@
     mode: 0644
 
 - name: Generate random VPN client names
-  shell: "{{ streisand_word_gen.identifier }}"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/english.txt | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /./g'
   register: "vpn_client_names"
   with_sequence: count={{ vpn_clients }}
 

--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -30,6 +30,9 @@ streisand_common_packages:
   - qrencode
   # Used for automatically installing security updates
   - unattended-upgrades
+  # Word List dictionary used by several roles to generate random
+  # (yet typeable!) passphrases
+  - wamerican-huge
   # A UUID generator with an explicit random function.
   # Used for generating UUIDs for mobileconfig files
   - uuid
@@ -67,20 +70,3 @@ streisand_languages:
     file_suffix: "-fr"
     language_name: "Français"
     tor_locale: "fr"
-
-streisand_word_gen:
-  gateway:
-    shuf -n 6 /usr/share/dict/english.txt |
-    paste -s -d '.' -
-  identifier:
-    shuf -n 2 /usr/share/dict/english.txt |
-    paste -s -d '-' -
-  long_identifier:
-    shuf -n 3 /usr/share/dict/english.txt |
-    paste -s -d '-' -
-  weak_password:
-    shuf -n 3 /usr/share/dict/english.txt |
-    paste -s -d '.' -
-  psk:
-    shuf -n 5 /usr/share/dict/english.txt |
-    paste -s -d '.' -

--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -47,7 +47,7 @@
     mode: 0644
 
 - name: Generate a random IPsec pre-shared key
-  shell: "{{ streisand_word_gen.psk }}  > {{ ipsec_preshared_key_file }}"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 3 | xargs | sed -e 's/ /-/g' > {{ ipsec_preshared_key_file }}
   args:
     creates: "{{ ipsec_preshared_key_file }}"
 
@@ -101,7 +101,7 @@
     mode: 0644
 
 - name: Generate a random CHAP password
-  shell: "{{ streisand_word_gen.weak_password }} > {{ chap_password_file }}"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ /-/g' > {{ chap_password_file }}
   args:
     creates: "{{ chap_password_file }}"
 

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -83,7 +83,7 @@
     label: "{{ client_content[0].item }}"
 
 - name: Generate a random ocserv password
-  shell: "{{ streisand_word_gen.psk }} > {{ ocserv_password_file }}"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 4 | xargs | sed -e 's/ /-/g' > {{ ocserv_password_file }}
   args:
     creates: "{{ ocserv_password_file }}"
 

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -7,7 +7,7 @@
 - include_vars: ../../lets-encrypt/vars/main.yml
 
 - name: Generate a random Gateway password
-  shell: "{{ streisand_word_gen.gateway }} > {{ streisand_gateway_password_file }}"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 4 | xargs | sed -e 's/ /-/g' > {{ streisand_gateway_password_file }}
   args:
     creates: "{{ streisand_gateway_password_file }}"
 

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -27,7 +27,7 @@
 - import_tasks: firewall.yml
 
 - name: Generate a random Nickname for the bridge
-  shell: "{{ streisand_word_gen.identifier }} > {{ tor_bridge_nickname_file }}"
+  shell: grep -v -P "[\x80-\xFF]" /usr/share/dict/american-english-huge | sed -e "s/'//" | shuf -n 2 | xargs | sed -e 's/ //' | cut -c 1-16 > {{ tor_bridge_nickname_file }}
   args:
     creates: "{{ tor_bridge_nickname_file }}"
 


### PR DESCRIPTION
This reverts commit 3d153287c889cc95f268e82d5807ea82b573f6a9, reversing changes made to 9baef3eceeaf94cd823eb376eee00096de2f7b15.

This commit was causing a [tor regression](https://github.com/StreisandEffect/streisand/issues/1103). 

Resolves #1103 

_Note: Happy to close this if we have a fix for the root cause of 1103 to prefer_