### PR TITLE
Fix tor bridge nickname

### DIFF
--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -75,6 +75,18 @@ streisand_word_gen:
   identifier:
     shuf -n 2 /usr/share/dict/english.txt |
     paste -s -d '-' -
+  # Tor only likes [A-Za-z0-9] for nicknames.
+  #
+  # The BIP words are maximum 8 characters, so we get two safely.
+  #
+  # Tor nicknames should be 19 characters or fewer; cut ours off at 18.
+  #
+  # Caps script from https://www.unix.com/302904939-post2.html
+  tor_nickname:
+    shuf -n 2 ~/share/dict/english.txt |
+    awk '{OFS=""; for(j=1;j<=NF;j++){ $j=toupper(substr($j,1,1)) substr($j,2) }}1' |
+    tr -d '\n' |
+    cut -b 1-18
   long_identifier:
     shuf -n 3 /usr/share/dict/english.txt |
     paste -s -d '-' -

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -27,8 +27,7 @@
 - import_tasks: firewall.yml
 
 - name: Generate a random Nickname for the bridge
-  shell: "{{ streisand_word_gen.tor_nickname }} > {{ tor_bridge_nickname_file }}"
-  args:
+  shell: "{{ streisand_word_gen.tor_nickname }} > {{ tor_bridge_nickname_file }}  args:
     creates: "{{ tor_bridge_nickname_file }}"
 
 - name: Register the bridge's random Nickname

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -27,7 +27,8 @@
 - import_tasks: firewall.yml
 
 - name: Generate a random Nickname for the bridge
-  shell: "{{ streisand_word_gen.tor_nickname }} > {{ tor_bridge_nickname_file }}  args:
+  shell: "{{ streisand_word_gen.tor_nickname }} > {{ tor_bridge_nickname_file }}"
+  args:
     creates: "{{ tor_bridge_nickname_file }}"
 
 - name: Register the bridge's random Nickname

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -27,7 +27,7 @@
 - import_tasks: firewall.yml
 
 - name: Generate a random Nickname for the bridge
-  shell: "{{ streisand_word_gen.identifier }} > {{ tor_bridge_nickname_file }}"
+  shell: "{{ streisand_word_gen.tor_nickname }} > {{ tor_bridge_nickname_file }}"
   args:
     creates: "{{ tor_bridge_nickname_file }}"
 


### PR DESCRIPTION
For nicknames, we need 1-19 characters from `[A-Za-z0-9]`. Our wordlist has a bunch of 8-character words, so we're limited to two words for this. **TitleCase** the words for moderately better recognition. Chop at 18 characters in case our wordlist gets expanded.