### PR TITLE
Update ubuntu-dependences and venv-scripts

### DIFF
--- a/util/ubuntu-dependencies.sh
+++ b/util/ubuntu-dependencies.sh
@@ -54,6 +54,8 @@ python-dev
 python-setuptools
 python-pip
 python-cffi libffi-dev
+libssl-dev
+libcurl4-openssl-dev
 EOF
 )
 
@@ -69,26 +71,9 @@ our_pip_install pip
 # The pip we want should be in our path now. Make sure we use it.
 hash -r
 
-our_pip_install ansible
-
-# Python dependencies for various providers. Note that
-# "ansible[azure]" means "install ansible, and add additional
-# dependencies packages from ansible's 'azure' set. Since ansible is
-# already installed (see above), this just means "Azure dependencies".
-
-packages="$(cat <<EOF
-boto boto3
-ansible[azure]
-dopy==0.3.5
-apache-libcloud>=1.5.0 pycrypto
-linode-python
-pyrax
-EOF
-)"
-
 # We explicitly want word splitting.
 # shellcheck disable=SC2059,SC2086
-our_pip_install $packages
+our_pip_install -r requirements.txt
 
 echo '
 Streisand dependencies installed.

--- a/util/venv-dependencies.sh
+++ b/util/venv-dependencies.sh
@@ -90,6 +90,8 @@ build-essential
 libffi-dev
 python-dev
 python-pip
+libssl-dev
+libcurl4-openssl-dev
 EOF
 )"
 


### PR DESCRIPTION
As `pycurl` is required for `linode-python`, `pycurl` also depends on having `libssl-dev` and `libcurl4-openssl-dev` to be installed prior to setup.

This PR updates the `ubuntu-dependencies.sh` and `venv-dependencies.sh` scripts to require the dependencies, ensuring a smooth and clean setup process.

As the pip requirements are now externalized into a separate file, an additional minor refactor makes use of the text file in `ubuntu-dependencies.sh`, reducing duplicate code.

Tested on 2 fresh Digital Ocean droplets, one running the first script only and the other running the latter with no apparent issues.