### PR TITLE
Configure TinyProxy to allow connections from server IP.

### DIFF
--- a/playbooks/roles/tinyproxy/tasks/main.yml
+++ b/playbooks/roles/tinyproxy/tasks/main.yml
@@ -10,6 +10,13 @@
     line: "Listen 127.0.0.1"
   notify: Restart Tinyproxy
 
+- name: Reconfigure TinyProxy to accept connections from the Streisand server IP
+  lineinfile:
+    dest: /etc/tinyproxy.conf
+    line: "Allow {{ streisand_ipv4_address }}"
+    insertafter: "^Allow 127\\.0\\.0\\.1$"
+    state: present
+
 - name: Reconfigure Tinyproxy so it doesn't log incoming connections
   lineinfile:
     dest: /etc/tinyproxy.conf


### PR DESCRIPTION
Prior to this commit the TinyProxy config on the Streisand server only
had an entry for `Allow 127.0.0.1` - You would _think_ this would be
sufficient for a port forwarded request to be allowed but testing seems
to indicate (You need to increase the verbosity level to see this) the
connection is refused as coming from the Streisand server's own IP. The
client is given a 403 Access Denied error page in response from
TinyProxy.

TinyProxy only binds to `127.0.0.1` and we don't expose its port
(`8888`) through the UFW firewall or the cloud environment network
policies. It should be safe to allow connections from the server's own
IPv4 address and testing confirms this does fix the access denied errors
from TinyProxy.