### PR TITLE
Update ./streisand documentation

### DIFF
--- a/streisand
+++ b/streisand
@@ -128,7 +128,7 @@ Please enter the word 'streisand' to continue: "
 }
 
 function existing_server() {
-  read -r -p "What is the IP of the existing server: " SERVER_IP
+  read -r -p "What is the IP of the existing server (you may choose to set a domain name later): " SERVER_IP
 
   be_careful_friend "
 THIS WILL OVERWRITE CONFIGURATION ON THE EXISTING SERVER.


### PR DESCRIPTION
I think it's a good idea to mention to the user that the IP is separate from the domain name they use to setup, and that they can set it up later. I spent a couple hours trying to use a FQDN for my IP only to realize that's a setting that comes up later...