### PR TITLE
Added the 'Mode' setting under 'Additional TLS Auth' settings for OpenVpn for Ubuntu 17.10

### DIFF
--- a/playbooks/roles/openvpn/templates/instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions.md.j2
@@ -125,6 +125,7 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
    * Under *Server Certificate Check* choose `verify name exactly` and enter `{{ openvpn_server_common_name.stdout }}` as its value.
    * Check *Verify peer (server) certificate usage signature*.
    * Check *Use additional TLS authentication*.
+     * Select TLS-Auth as the Mode
      * Select the `ta.key` file you downloaded from the client-files directory for the *Key File*.
      * Select `1` as the *Key Direction*.
    * Click *OK*.

--- a/playbooks/roles/openvpn/templates/instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions.md.j2
@@ -125,7 +125,7 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
    * Under *Server Certificate Check* choose `verify name exactly` and enter `{{ openvpn_server_common_name.stdout }}` as its value.
    * Check *Verify peer (server) certificate usage signature*.
    * Check *Use additional TLS authentication*.
-     * Select TLS-Auth as the Mode
+     * Select `TLS-Auth` as the *Mode*.
      * Select the `ta.key` file you downloaded from the client-files directory for the *Key File*.
      * Select `1` as the *Key Direction*.
    * Click *OK*.


### PR DESCRIPTION
I just noticed on Ubuntu 17.10, when setting up OpenVPN, it was missing a 'Mode' setting under 'Additional TLS authentication or encryption'. As a result I pulled the file, added the line instructing the user to select TLS-Auth for their mode (that is the only viable option) and have submitted a pull request.

I checked to make sure there wasn't already an existing issue or pull request, so I apologize if I missed it. Let me know if you need screenshots or anything else for confirmation.

**As a side note, I'm noticing that Travis CI is failing this, and other pull requests because of a missing file at https://images.linuxcontainers.org/1.0/images/ubuntu%2Fxenial%2Famd64. If someone could fix that, that would be great :)**