### PR TITLE
Update instructions for Firefox certificate import

### DIFF
--- a/playbooks/roles/streisand-gateway/templates/instructions.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/instructions.md.j2
@@ -144,9 +144,9 @@ These instructions work for Chrome. Firefox for Android uses its own internal Ce
 <a name="ssl-firefox"></a>
 ### Firefox ###
 1. Launch Firefox.
-1. Open the *Options > Preferences* panel.
-1. Click on the *Advanced* icon.
-1. Go to the *Certificates* tab.
+1. Open the *Options* panel.
+1. Go to the *Privacy & Security* tab.
+1. Scroll down to the *Security > Certificates* heading 
 1. Click *View Certificates*.
 1. A window will appear. Click on the *Authorities* tab.
 1. [Download the SSL certificate](#download) embedded in this document.

--- a/playbooks/roles/streisand-gateway/templates/instructions.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/instructions.md.j2
@@ -146,7 +146,7 @@ These instructions work for Chrome. Firefox for Android uses its own internal Ce
 1. Launch Firefox.
 1. Open the *Options* panel.
 1. Go to the *Privacy & Security* tab.
-1. Scroll down to the *Security > Certificates* heading 
+1. Scroll down to the *Security > Certificates* heading.
 1. Click *View Certificates*.
 1. A window will appear. Click on the *Authorities* tab.
 1. [Download the SSL certificate](#download) embedded in this document.


### PR DESCRIPTION
Firefox changed its settings menu in version 57. This just updates the instructions in the generated doc for importing the certificate.

I've tried this method with Firefox 57.0.2 on Windows 10 and Windows 7.