### PR TITLE
fixing inconsistency in apache-libcloud requirement for GCE

### DIFF
--- a/README-chs.md
+++ b/README-chs.md
@@ -140,7 +140,7 @@ Streisand 运行在**你自己的计算机上时（或者你电脑的虚拟机�
         sudo pip install dopy==0.3.5
   * Google
 
-        sudo pip install "apache-libcloud>=1.5.0"
+        sudo pip install "apache-libcloud>=1.17.0"
   * Linode
 
         sudo pip install linode-python

--- a/README-ru.md
+++ b/README-ru.md
@@ -140,7 +140,7 @@
         sudo pip install dopy==0.3.5
   * Google
 
-        sudo pip install "apache-libcloud>=1.5.0"
+        sudo pip install "apache-libcloud>=1.17.0"
 
   * Linode
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Complete all of these tasks on your local home machine.
         sudo pip install dopy==0.3.5
   * Google
 
-        sudo pip install "apache-libcloud>=1.5.0"
+        sudo pip install "apache-libcloud>=1.17.0"
 
   * Linode
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ packaging
 dopy==0.3.5
 
 # Google Compute Engine
-apache-libcloud>=1.5.0
+apache-libcloud>=1.17.0
 
 # Linode
 pycurl


### PR DESCRIPTION
The French README already had this change, but instead of installing "apache-libcloud>=1.5.0", the user should install a version greater than 1.17.0. Although using the >=1.5.0 function will install apache-libcloud 2.2.1, it seemed better for both the sake of consistency and to avoid any bugs to ensure that the installed version is above the specified minimum in Ansible for use with Google's JSON credentials, which Streisand uses.

Look here for Ansible's documentation:
http://docs.ansible.com/ansible/latest/gce_module.html
