### PR TITLE
Fix CI (again)

### DIFF
--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -80,6 +80,12 @@
         path: /var/lib/lxd/unix.socket
         mode: "0777"
 
+    - name: Retrieve the Ubuntu Xenial AMD64 LXC image fingerprint
+      uri:
+        url: https://images.linuxcontainers.org/1.0/images/aliases/ubuntu/xenial/amd64
+        return_content: yes
+      register: xenial_fingerprint
+
     - name: Launch streisand container (this will take a while)
       lxd_container:
         name: streisand
@@ -89,8 +95,8 @@
           mode: pull
           server: https://images.linuxcontainers.org
           protocol: lxd
-          # This fingerprint references the ubuntu/xenial/amd64 image
-          alias: 15979fa5ecd96e183d08a83451752bed05e63d1f21a2aae9e7162d19d54996f7
+          # Use the retrieved alias to fetch the image
+          alias: "{{ xenial_fingerprint['json']['metadata']['target'] }}"
         profiles: ["default"]
         config:
           security.privileged: "true"


### PR DESCRIPTION
LXC image fingerprints appear to change often.

This PR fetches the latest fingerprint for Ubuntu Xenial/amd64 and used to pull in the correct image.