### PR TITLE
Update ss-libev from tag: 3.1.1 to 3.1.2

### DIFF
--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -19,7 +19,7 @@ shadowsocks_dependencies:
   - rng-tools
   - libssl-dev
 
-shadowsocks_version: "3.1.1"
+shadowsocks_version: "3.1.2"
 shadowsocks_compilation_directory: "/usr/local/src/shadowsocks-libev-{{ shadowsocks_version }}"
 
 # Configuring the build without documentation means we save close to 900mb of deps


### PR DESCRIPTION
Upstream developers have updated the `shadowsocks-libev` version from `3.1.1` to `3.1.2`. [Changelog](https://github.com/shadowsocks/shadowsocks-libev/blob/master/debian/changelog) can be accessed here. 