### PR TITLE
Updated Wording for OpenVPN - Ubuntu for Ubuntu 17.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ Complete all of these tasks on your local home machine.
 * Streisand requires a BSD, Linux, or macOS system. As of now, Windows is not supported. All of the following commands should be run inside a Terminal session.
 * Python 2.7 is required. This comes standard on macOS, and is the default on almost all Linux and BSD distributions as well. If your distribution packages Python 3 instead, you will need to install version 2.7 in order for Streisand to work properly.
 * Make sure an SSH key is present in ~/.ssh/id\_rsa.pub.
+  * SSH keys use public-key cryptography to prove your identity.
+  * To check if you have a SSH key please run the following command at a Bash prompt:
+        
+        ls ~/.ssh/
+  * If you see a id_rsa.pub file, then you have an SSH key.
   * If you do not have an SSH key, you can generate one by using this command and following the defaults:
 
         ssh-keygen
+  * If you want to use a differently named key, or one in a non-standard directory, please enter "yes" when asked if you'd like to customize your Streisand instance during installation. 
 * Install Git.
   * On Debian and Ubuntu
 

--- a/README.md
+++ b/README.md
@@ -97,15 +97,9 @@ Complete all of these tasks on your local home machine.
 * Streisand requires a BSD, Linux, or macOS system. As of now, Windows is not supported. All of the following commands should be run inside a Terminal session.
 * Python 2.7 is required. This comes standard on macOS, and is the default on almost all Linux and BSD distributions as well. If your distribution packages Python 3 instead, you will need to install version 2.7 in order for Streisand to work properly.
 * Make sure an SSH key is present in ~/.ssh/id\_rsa.pub.
-  * SSH keys use public-key cryptography to prove your identity.
-  * To check if you have a SSH key please run the following command at a Bash prompt:
-        
-        ls ~/.ssh/
-  * If you see a id_rsa.pub file, then you have an SSH key.
   * If you do not have an SSH key, you can generate one by using this command and following the defaults:
 
         ssh-keygen
-  * If you want to use a differently named key, or one in a non-standard directory, please enter "yes" when asked if you'd like to customize your Streisand instance during installation. 
 * Install Git.
   * On Debian and Ubuntu
 

--- a/playbooks/roles/openvpn/templates/instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions.md.j2
@@ -124,12 +124,12 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
 1. Go to the *TLS Authentication* tab.
    * Under *Server Certificate Check* choose `verify name exactly` and enter `{{ openvpn_server_common_name.stdout }}` as its value.
    * Check *Verify peer (server) certificate usage signature*.
-   * Check *Use additional TLS authentication*.
+   * Go to *Additional TLS authentication or encryption*.
      * Select `TLS-Auth` as the *Mode*.
      * Select the `ta.key` file you downloaded from the client-files directory for the *Key File*.
      * Select `1` as the *Key Direction*.
    * Click *OK*.
-1. Click *Save...*
+1. Click *Add*
 1. Select the VPN in the left-hand menu, and flip the switch to *ON*. You can also enable/disable the VPN by clicking on the WiFi/Network icon in the menu bar, scrolling to *VPN Connections*, and clicking on its name.
 1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 


### PR DESCRIPTION
This may be a little nit-picky but I noticed that some of the wording is off for installing OpenVPN on Ubuntu. I think some changes were made in 17.10 and now things are laid out a little differently. 

I made 2 changes to the instructions. First, Instead of telling the user to check a box (it not longer exists), I mentioned that they should view a particular section (so they can update that information).

Second, there is no 'Save' button anymore, it is now referred to as 'Add'. I've linked some screenshots below.

[No Check Box](http://frichetten.com/images/z-9.png)
[No Save Button](http://frichetten.com/images/z-10.png)