### PR TITLE
Updated Wording for OpenVPN - Ubuntu for Ubuntu 17.10 (Fixed)

### DIFF
--- a/playbooks/roles/openvpn/templates/instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions.md.j2
@@ -124,12 +124,12 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
 1. Go to the *TLS Authentication* tab.
    * Under *Server Certificate Check* choose `verify name exactly` and enter `{{ openvpn_server_common_name.stdout }}` as its value.
    * Check *Verify peer (server) certificate usage signature*.
-   * Check *Use additional TLS authentication*.
+   * Go to *Additional TLS authentication or encryption*.
      * Select `TLS-Auth` as the *Mode*.
      * Select the `ta.key` file you downloaded from the client-files directory for the *Key File*.
      * Select `1` as the *Key Direction*.
    * Click *OK*.
-1. Click *Save...*
+1. Click *Add*
 1. Select the VPN in the left-hand menu, and flip the switch to *ON*. You can also enable/disable the VPN by clicking on the WiFi/Network icon in the menu bar, scrolling to *VPN Connections*, and clicking on its name.
 1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 


### PR DESCRIPTION
This may be a little nit-picky but I noticed that some of the wording is off for installing OpenVPN on Ubuntu. I think some changes were made in 17.10 and now things are laid out a little differently.

I made 2 changes to the instructions. First, Instead of telling the user to check a box (it no longer exists), I mentioned that they should view a particular section (so they can update that information).

Second, there is no 'Save' button anymore, it is now referred to as 'Add'. I've linked some screenshots below.

[No Check Box](http://frichetten.com/images/z-9.png)
[No Save Button](http://frichetten.com/images/z-10.png)

If this looks like a repeat, it is. This was originally Pull Request #1149 . I wanted to make a quick fix so I did it on my Master branch. After that, I found something different to work on. To save the headache, I just closed it and did it the proper way :P