### PR TITLE
Updated README to Clarify Information Regarding SSH Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Complete all of these tasks on your local home machine.
 * Streisand requires a BSD, Linux, or macOS system. As of now, Windows is not supported. All of the following commands should be run inside a Terminal session.
 * Python 2.7 is required. This comes standard on macOS, and is the default on almost all Linux and BSD distributions as well. If your distribution packages Python 3 instead, you will need to install version 2.7 in order for Streisand to work properly.
 * Make sure an SSH key is present in ~/.ssh/id\_rsa.pub.
-  * SSH keys use public-key cryptography to prove your identity to a server or service.
-  * To check if you already have an SSH key, please enter the following command at a Bash prompt.
+  * SSH keys are a more secure alternative to passwords that allow you to prove your identity to a server or service built on public key cryptography.
+  * To check if you already have an SSH key, please enter the following command at a command prompt.
   
         ls ~/.ssh
   * If you see an id_rsa.pub file, then you have an SSH key.

--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ Complete all of these tasks on your local home machine.
 * Streisand requires a BSD, Linux, or macOS system. As of now, Windows is not supported. All of the following commands should be run inside a Terminal session.
 * Python 2.7 is required. This comes standard on macOS, and is the default on almost all Linux and BSD distributions as well. If your distribution packages Python 3 instead, you will need to install version 2.7 in order for Streisand to work properly.
 * Make sure an SSH key is present in ~/.ssh/id\_rsa.pub.
+  * SSH keys use public-key cryptography to prove your identity to a server or service.
+  * To check if you already have an SSH key, please enter the following command at a Bash prompt.
+  
+        ls ~/.ssh
+  * If you see an id_rsa.pub file, then you have an SSH key.
   * If you do not have an SSH key, you can generate one by using this command and following the defaults:
 
         ssh-keygen
+  * If you'd like to use an SSH key with a different name or in a non-standard location, please enter 'yes' when asked if you'd like to customize your instance during installation.
 * Install Git.
   * On Debian and Ubuntu
 


### PR DESCRIPTION
Added clarifying information in the README in regards to SSH keys. This was requested under Issue #1138. 

I'm happy to discuss ways for this to be improved! My primary goal was to explain a basic synopsis of what SSH keys are for, how to check if you have one, and mention that you can use a custom one when customizing your streisand instance.