### PR TITLE
Add `boto3` to AWS requirements in READMEs.

### DIFF
--- a/README-chs.md
+++ b/README-chs.md
@@ -132,7 +132,7 @@ Streisand 运行在**你自己的计算机上时（或者你电脑的虚拟机�
 * 以下使用 pip 安装的 Python 库根据你所使用的 VPS 供应商不同而不同。如果你准备将目前使用的 VPS 变成网关，可以跳过此步。
   * 亚马逊 EC2
 
-        sudo pip install boto
+        sudo pip install boto boto3
   * 微软云服务
 
         sudo pip install ansible[azure]

--- a/README-fr.md
+++ b/README-fr.md
@@ -133,7 +133,7 @@ Effectuez toutes ces tâches sur votre machine locale.
 * Installez les bibliothèques Python nécessaires pour votre fournisseur de cloud.
   * Amazon EC2
 
-            sudo pip install boto
+            sudo pip install boto boto3
   * Azure
 
             sudo pip install ansible[azure]

--- a/README-ru.md
+++ b/README-ru.md
@@ -132,7 +132,7 @@
 * Установите необходимые библиотеки Python для вашего облачного хостера. Если вы настраиваете локальный или существующий сервер, вы можете пропустить этот шаг.
   * Amazon EC2
 
-        sudo pip install boto
+        sudo pip install boto boto3
   * Azure
 
         sudo pip install ansible[azure]

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Complete all of these tasks on your local home machine.
     you can skip this section.
   * Amazon EC2
 
-        sudo pip install boto
+        sudo pip install boto boto3
   * Azure
 
         sudo pip install ansible[azure]


### PR DESCRIPTION
**Both** `boto` and `boto3` are required to provision an AWS instance
using the libraries/Ansible version shipped in master.
`requirements.txt` has already been updated, the individual READMEs
should be updated as well.

This supersedes https://github.com/StreisandEffect/streisand/pull/1126 Thanks to @taqtiqa-admin for flagging the
issue initially.