### PR TITLE
Harden links

### DIFF
--- a/playbooks/roles/sysctl/vars/main.yml
+++ b/playbooks/roles/sysctl/vars/main.yml
@@ -25,3 +25,5 @@ sysctl_values:
   - { key: net.core.wmem_max, value: 12582912 }
   - { key: net.core.rmem_max, value: 12582912 }
   - { key: fs.suid_dumpable, value: 0 }
+  - { key: fs.protected_hardlinks, value: 1 }
+  - { key: fs.protected_symlinks, value: 1 }


### PR DESCRIPTION
Explicitly set `fs.protected_hardlinks` and `fs.protected_symlinks` sysctl values to enabled.

Edit: tested on a vagrant e2e run.