### PR TITLE
Make LE email address optional

### DIFF
--- a/playbooks/lets-encrypt.yml
+++ b/playbooks/lets-encrypt.yml
@@ -30,10 +30,13 @@
 
     - name: "streisand_admin_email_var"
       prompt: |
-        Which email address do you want to use as contact of Streisand server?
+        Which email address do you want to use as contact for the Streisand
+        server's Let's Encrypt certificate?
 
-        This is an optional question. The email is only used as contact method
-        of your Let's Encrypt account.
+        This is an optional question. Let's Encrypt will issue a certificate
+        without providing an email address, however it is highly recommended
+        you do. The email is only used as contact method of your Let's
+        Encrypt account.
 
         Please type your email below. Press enter to skip.
       private: no
@@ -47,12 +50,11 @@
     - name: Set Streisand admin email
       set_fact:
         streisand_admin_email: "{{ streisand_admin_email_var }}"
-      when: streisand_admin_email_var != ""
 
     - name: Enable Let's Encrypt role
       set_fact:
         streisand_le_enabled: yes
-      when: streisand_domain_var != "" and streisand_admin_email_var != ""
+      when: streisand_domain_var != ""
 
     - name: Disable Let's Encrypt role
       set_fact:
@@ -60,5 +62,5 @@
         streisand_domain: ""
         streisand_admin_email: ""
         le_ok: False
-      when: streisand_domain_var == "" or streisand_admin_email_var == ""
+      when: streisand_domain_var == ""
 ...

--- a/playbooks/lets-encrypt.yml
+++ b/playbooks/lets-encrypt.yml
@@ -33,10 +33,11 @@
         Which email address do you want to use as contact for the Streisand
         server's Let's Encrypt certificate?
 
-        This is an optional question. Let's Encrypt will issue a certificate
-        without providing an email address, however it is highly recommended
-        you do. The email is only used as contact method of your Let's
-        Encrypt account.
+        This is an optional question. If you supply an email address, Let's
+        Encrypt will send you important (but very infrequent) notifications
+        about using the certificate. This mail includes any upcoming certificate
+        expirations, and important changes to the Let's Encrypt service.
+        The email will not be used for anything else.
 
         Please type your email below. Press enter to skip.
       private: no


### PR DESCRIPTION
- Allow LE role to run when no email is provided
- Update copy to reflect this but emphasise desirability