### PR TITLE
Update ssh config docs to include `IdentitiesOnly`.

### DIFF
--- a/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
@@ -70,10 +70,11 @@ Sshuttle est une simple solution de tunneling VPN qui fonctionne sur le transpor
 1. Ajoutez une nouvelle entrée à votre fichier `.ssh / config`. Il devrait ressembler à ceci.Le port `443` est disponible en option de recharge si vous êtes sur un réseau qui restreint l'accès au port SSH par défaut. Assurez-vous d'ajuster l'emplacement du IdentityFile:
 
          Host {{ streisand_server_name }}
-           User         sshuttle 
-           Port         {{ ssh_port }}
-           HostName     {{ streisand_ipv4_address }}
-           IdentityFile ~/.ssh/streisand_rsa
+           User           sshuttle
+           Port           {{ ssh_port }}
+           HostName       {{ streisand_ipv4_address }}
+           IdentitiesOnly yes
+           IdentityFile   ~/.ssh/streisand_rsa
 
 1. Téléchargez [sshuttle](https://github.com/sshuttle/sshuttle) en exécutant la commande suivante dans une répertoire de votre choix:
 
@@ -103,10 +104,11 @@ Sshuttle est une simple solution de tunneling VPN qui fonctionne sur le transpor
 1. Ajoutez une nouvelle entrée à votre fichier `.ssh / config`. Il devrait ressembler à ceci.Le port `443` est disponible en option de recharge si vous êtes sur un réseau qui restreint l'accès au port SSH par défaut. Assurez-vous d'ajuster l'emplacement du IdentityFile:
 
          Host {{ streisand_server_name }}
-           User         forward
-           Port         {{ ssh_port }}
-           HostName     {{ streisand_ipv4_address }}
-           IdentityFile ~/.ssh/streisand_rsa
+           User           forward
+           Port           {{ ssh_port }}
+           HostName       {{ streisand_ipv4_address }}
+           IdentitiesOnly yes
+           IdentityFile   ~/.ssh/streisand_rsa
 
 1. `SSH`ez dans le serveur et transférer un port SOCKS dynamique:
 

--- a/playbooks/roles/ssh-forward/templates/instructions.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions.md.j2
@@ -66,10 +66,11 @@ You are now connected and have a SOCKS proxy up and running that is ready to for
 1. Add a new entry to your `.ssh/config` file. It should look like this. Port `443` is available as a fallback option if you are on a network that restricts access to the default SSH port. Be sure to adjust the location of the IdentityFile:
 
          Host {{ streisand_server_name }}
-           User         forward
-           Port         {{ ssh_port }}
-           HostName     {{ streisand_ipv4_address }}
-           IdentityFile ~/.ssh/streisand_rsa
+           User           forward
+           Port           {{ ssh_port }}
+           HostName       {{ streisand_ipv4_address }}
+           IdentitiesOnly yes
+           IdentityFile   ~/.ssh/streisand_rsa
 
 1. SSH into the server and forward a dynamic SOCKS port:
 
@@ -94,10 +95,11 @@ Sshuttle is a simple VPN tunnelling solution that operates over the SSH transpor
 1. Add a new entry to your `.ssh/config` file. It should look like this. Port `443` is available as a fallback option if you are on a network that restricts access to the default SSH port. Be sure to adjust the location of the IdentityFile:
 
          Host {{ streisand_server_name }}
-           User         sshuttle
-           Port         {{ ssh_port }}
-           HostName     {{ streisand_ipv4_address }}
-          IdentityFile ~/.ssh/streisand_rsa
+           User           sshuttle
+           Port           {{ ssh_port }}
+           HostName       {{ streisand_ipv4_address }}
+           IdentitiesOnly yes
+           IdentityFile   ~/.ssh/streisand_rsa
 
 1. Download [sshuttle](https://github.com/sshuttle/sshuttle) by running the following command in the directory of your choice:
 


### PR DESCRIPTION
Without using `IdentitiesOnly yes` ssh client tries all the identity files in alphabetical order like following

```
debug1: SSH2_MSG_SERVICE_ACCEPT received
debug2: key: /Users/kyslik/.ssh/bitbucket_rsa (0x7f930a5005e0),
debug2: key: do_vpn_forward_rsa (0x7f930a415eb0), explicit
debug2: key: /Users/kyslik/.ssh/do_vpn_forward_rsa (0x7f930a415ee0), explicit
debug1: Authentications that can continue: publickey
debug3: start over, passed a different list publickey
debug3: preferred publickey,keyboard-interactive,password
debug3: authmethod_lookup publickey
debug3: remaining preferred: keyboard-interactive,password
debug3: authmethod_is_enabled publickey
debug1: Next authentication method: publickey
debug1: Offering RSA public key: /Users/kyslik/.ssh/bitbucket_rsa
debug3: send_pubkey_test
debug2: we sent a publickey packet, wait for reply
debug1: Authentications that can continue: publickey
debug1: Offering RSA public key: do_vpn_forward_rsa
debug3: send_pubkey_test
debug2: we sent a publickey packet, wait for reply
debug1: Authentications that can continue: publickey
debug1: Offering RSA public key: /Users/kyslik/.ssh/do_vpn_forward_rsa
```