### PR TITLE
GCP: Use distinct name for stunnel firewall rule

### DIFF
--- a/playbooks/roles/gce-network/tasks/main.yml
+++ b/playbooks/roles/gce-network/tasks/main.yml
@@ -100,7 +100,7 @@
 - name: Open the OpenVPN stunnel port in the GCE firewall
   gce_net:
     name: "{{ gce_network }}"
-    fwname: "streisand-{{ gce_server_name }}-openvpn"
+    fwname: "streisand-{{ gce_server_name }}-openvpn-stunnel"
     allowed: "tcp:{{ stunnel_remote_port }}"
     state: "present"
     mode: auto


### PR DESCRIPTION
Prior to this commit the GCP stunnel firewall rule was created under the
same name as the OpenVPN firewall rule. This would stomp the OpenVPN
ports when stunnel was enabled. This commit uses a distinct name for the
stunnel firewall rule so that both it and the base OpenVPN rule can
coexist.

I verified that without this commit, I see the problem described in #1182. With 
this commit the correct rules are added.

Resolves https://github.com/StreisandEffect/streisand/issues/1182