### PR TITLE
Update LibreSwan to v3.23

### DIFF
--- a/playbooks/roles/l2tp-ipsec/vars/main.yml
+++ b/playbooks/roles/l2tp-ipsec/vars/main.yml
@@ -19,7 +19,7 @@ libreswan_compilation_dependencies:
   - libldns-dev
   - pkg-config
 
-libreswan_version: "3.22"
+libreswan_version: "3.23"
 libreswan_src_directory: "/usr/local/src"
 libreswan_compilation_directory: "{{ libreswan_src_directory }}/libreswan-{{ libreswan_version }}"
 libreswan_source_filename: "libreswan-{{ libreswan_version }}.tar.gz"


### PR DESCRIPTION
Changelog: https://download.libreswan.org/CHANGES

```
v3.23 (January 25, 2018)
* IKEv2: MOBIKE support (RFC 45555) [Antony/Paul]
* IKEv2: Add support for modecfgdns= and modecfgdomains= like for IKEv1 [Paul]
* IKEv2: EXPERIMENTAL: Support for Postquantim Preshared Keys [Vukasin Karadzic]
         based on draft-ietf-ipsecme-qr-ikev2-01 (using private use numbers)
         new option: ppk=yes|no|insist (default no)
* pluto: Fix DEFAULT_RUNDIR to be set so it is really configurable [Tuomo]
* pluto: Add support IDr payload (You Tarzan, me Jane) [Paul]
* pluto: pass state to send_crypto_helper_request() [Andrew]
* pluto: Internal time/scheduling changes, micro-seconds logging [Andrew]
* pluto: make counts of states consistently "unsigned" [Hugh]
* pluto/lib: Remove obsoleted/unused %myid support [Paul]
* pluto: add --impair replay-forward,replay-backward [Andrew]
* pluto: add --impair dup-incoming-packets [Andrew]
* pluto: Rework nic offload detection code [Aviv Heller]
* pluto: Retry send on -EAGAIN in check_msg_errqueue() (upto 32x) [Paul/Hugh]
* pluto: Pull latest kernel traffic counters before logging/deleting SA [Paul]
* pluto: STF_INLINE, STF_TOOMUCHCRYPTO no longer needed in helpers [Andrew]
* pluto: Replace socket queues with a simple queue and mutex+cont [Andrew]
* pluto: Do not send DPD/liveness probes for replaced inactive IPsec SAs [Paul]
* pluto: crypto processing cleanup [Andrew]
* XFRM: XFRM_MIGRATE support, used for MOBIKE [Antony]
* XFRM: Listen to NETLINK_ROUTE messages from kernel for MOBIKE [Antony]
* XFRM: Fix unique marks accidentally setting -1 instead of random [Paul]
* XFRM: Only install IPv6 holes when system has configured IPv6 [Antony]
* XFRM: Add support for decap-dscp=yes|no (default no) [Paul]
* XFRM: Add support for nopmtudisc=yes|no (default no) [Paul]
* KLIPS: Support kernels 4.14+ with renamed dev->priv_destructor [Paul]
* KLIPS: updown fixes for IPv6 default route and metric/mtu settings [Wolfgang]
* SECCOMP: Update syscall whitelist for use of libunbound [Paul]
* IKEv1: better handle ESP with no integrity vs unknown integrity [Andrew]
* IKEv1: Fix packet retransmit code wrf timeouts vs duplucates [Andrew]
* IKEv1: Prevent duplicate responder states on retransmision [Andrew]
* IKEv1: Don't linger R1 states for 1h but use configured timeouts [Paul]
* IKEv2: nat_traversal_change_port_lookup() code moved [Antony]
* IKEv2: Macros could misinterpret some IKE/IPsec states [Paul/Antony]
* IKEv2: Updated Group transforms to comply with RFC 8247 [Paul]
* PAM: Don't cancel pam threads (unsupported!) but drop results instead [Andrew]
* _updown: Fix resolv.conf handling (github #130) [Tuomo]
* _updown: Fix POINTPOINT interfaces not to use nexthop [Tuomo]
* _updown.netkey: Add source ip to dev lo by default [Tuomo]
* Makefiles: Fix INC_MANDIR to be share/man and add FINALMANDIR [Tuomo]
* packaging: Move debian/ to packaging ('make deb' still works) [Antony]
* contrib: Added ipsec-dyndns to demonstrante how push an IPSECKEY [Paul]
* Bugtracker bugs fixed:
   #313: changesource in updown_klips doesn't respect PLUTO_METRIC [Wolfgang]
   #314: IPv6 default route is deleted by mistake [Wolfgang]
```