### PR TITLE
Update `syntax-check.yml`

### DIFF
--- a/playbooks/roles/certificates/tasks/pkcs.yml
+++ b/playbooks/roles/certificates/tasks/pkcs.yml
@@ -37,7 +37,8 @@
     -out {{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}.p12
     -certfile {{ tls_client_path }}/ca.crt
     -passout pass:"{{ vpn_client_password.stdout }}"
-  creates: "{{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}.p12"
+  args:
+    creates: "{{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}.p12"
   with_items: "{{ vpn_client_pkcs12_password_list.results }}"
   loop_control:
     loop_var: "vpn_client_password"

--- a/tests/syntax-check.yml
+++ b/tests/syntax-check.yml
@@ -1,10 +1,11 @@
 ---
-#Include each playbook in order to check syntax of each playbook
+
+# Include each playbook in order to check syntax of each playbook
 - name: Include amazon.yml
   import_playbook: ../playbooks/amazon.yml
 
 - name: Include azure.yml
-  import_playbook: ../playbooks/streisand.yml
+  import_playbook: ../playbooks/azure.yml
 
 - name: Include cloud-status.yml
   import_playbook: ../playbooks/cloud-status.yml
@@ -12,17 +13,41 @@
 - name: Include digitalocean.yml
   import_playbook: ../playbooks/digitalocean.yml
 
+- name: Include existing-server.yml
+  import_playbook: ../playbooks/existing-server.yml
+
 - name: Include google.yml
   import_playbook: ../playbooks/google.yml
+
+- name: Include lets-encrypt.yml
+  import_playbook: ../playbooks/lets-encrypt.yml
 
 - name: Include linode.yml
   import_playbook: ../playbooks/linode.yml
 
+- name: Include localhost.yml
+  import_playbook: ../playbooks/localhost.yml
+
+- name: Include provider-detect.yml
+  import_playbook: ../playbooks/provider-detect.yml
+
+- name: Include python.yml
+  import_playbook: ../playbooks/python.yml
+
 - name: Include rackspace.yml
   import_playbook: ../playbooks/rackspace.yml
 
+- name: Include ssh-setup.yml
+  import_playbook: ../playbooks/ssh-setup.yml
+
 - name: Include streisand.yml
   import_playbook: ../playbooks/streisand.yml
+
+- name: Include test-client.yml
+  import_playbook: ../playbooks/test-client.yml
+
+- name: Include vagrant.yml
+  import_playbook: ../playbooks/vagrant.yml
 
 - name: Include run.yml
   import_playbook: run.yml
@@ -30,14 +55,17 @@
 - name: Include development-setup.yml
   import_playbook: development-setup.yml
 
-#Explicity include each role to ensure all roles are tested
+# Explicity include each role to ensure all roles are tested
 - hosts: localhost
   remote_user: root
   roles:
     - azure-security-group
+    - certificates
     - common
+    - diagnostics
     - diffie-hellman-group
     - dnsmasq
+    - download-and-verify
     - ec2-security-group
     - gce-network
     - genesis-amazon
@@ -48,17 +76,22 @@
     - genesis-rackspace
     - ip-forwarding
     - l2tp-ipsec
+    - lets-encrypt
     - monit
     - nginx
     - openconnect
     - openvpn
     - shadowsocks
     - ssh
+    - ssh-forward
     - sslh
     - streisand-gateway
     - streisand-mirror
     - stunnel
+    - sysctl
+    - test-client
     - tinyproxy
     - tor-bridge
     - ufw
+    - validation
     - wireguard


### PR DESCRIPTION
There's not a convenient way to dynamically import a playbook so
unfortunately we're left maintaining `syntax-check.yml` by hand. This commit
updates the playbooks and roles that were not being syntax checked. This 
proved to be worthwhile because it found one real bug in the `pkcs` tasks of the
`certificates` role!

Resolves https://github.com/StreisandEffect/streisand/issues/1184