### PR TITLE
Change Androïde to Android

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -43,12 +43,12 @@ Services fournis
 ----------------
 * L2TP/IPsec en utilisant [Libreswan](https://libreswan.org/) et [xl2tpd](https://www.xelerance.com/software/xl2tpd/)
   * Une clé et un mot de passe pré-partagés choisis au hasard sont générés.
-  * Les utilisateurs Windows, macOS, Androïde et iOS peuvent tous se connecter en utilisant le support VPN natif intégré à chaque système d'exploitation sans installer de logiciel supplémentaire.
+  * Les utilisateurs Windows, macOS, Android et iOS peuvent tous se connecter en utilisant le support VPN natif intégré à chaque système d'exploitation sans installer de logiciel supplémentaire.
 * [Monit](https://mmonit.com/monit/)
   * Surveille la santé du processus et redémarre automatiquement les services dans le cas improbable où ils se plante ou ne répondent pas.
 * [OpenSSH](http://www.openssh.com/)
-  * Les tunnels Windows et Androïde SSH sont également pris en charge et une copie des clés sont exportée dans le format .ppk que PuTTY requiert.
-  * [Tinyproxy](https://banu.com/tinyproxy/) est installé et lié à localhost. Il peut être accédé sur un tunnel SSH par des programmes qui ne prennent pas en charge nativement SOCKS et qui nécessitent un proxy HTTP, comme Twitter pour Androïde.
+  * Les tunnels Windows et Android SSH sont également pris en charge et une copie des clés sont exportée dans le format .ppk que PuTTY requiert.
+  * [Tinyproxy](https://banu.com/tinyproxy/) est installé et lié à localhost. Il peut être accédé sur un tunnel SSH par des programmes qui ne prennent pas en charge nativement SOCKS et qui nécessitent un proxy HTTP, comme Twitter pour Android.
   * Un utilisateur de transfert non privilégié et une paire paire de clés asymétriques SSH sont générés pour les fonctionnalités [sshuttle](https://github.com/sshuttle/sshuttle) et SOCKS.
 * [OpenConnect](http://www.infradead.org/ocserv/index.html)/[Cisco AnyConnect](http://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
   * OpenConnect (ocserv) est un serveur VPN extrêmement performant et léger qui offre également une compatibilité totale avec les clients officiels Cisco AnyConnect.
@@ -61,7 +61,7 @@ Services fournis
   * L'authentification TLS est activée, ce qui permet de vous protéger contre les attaques actives. Le trafic qui n'a pas de HMAC approprié est simplement abandonné.
 * [Shadowsocks](http://shadowsocks.org/en/index.html)
   * La [variante libev](https://github.com/shadowsocks/shadowsocks-libev) haute performance est installée. Cette version est capable de gérer des milliers de connexions simultanées.
-  * Un code QR est généré qui peut être utilisé pour configurer automatiquement les clients Androïde et iOS en prenant simplement une photo. Vous pouvez étiqueter "8.8.8.8" sur ce mur de béton, ou vous pouvez coller les instructions de Shadowsocks et quelques codes QR à la place!
+  * Un code QR est généré qui peut être utilisé pour configurer automatiquement les clients Android et iOS en prenant simplement une photo. Vous pouvez étiqueter "8.8.8.8" sur ce mur de béton, ou vous pouvez coller les instructions de Shadowsocks et quelques codes QR à la place!
   * [AEAD](https://shadowsocks.org/fr/spec/AEAD-Ciphers.html) est activé avec ChaCha20 et Poly1305 pour un contournement plus efficace du GFW.
   * Le plugin [simple-obfs](https://github.com/shadowsocks/simple-obfs) est installé afin de fournir une techique d'évasion du votre trafic sur des réseaux hostiles (en particulier ceux qui appliquent la limitation de la qualité de service (QOS)).
 * [sslh](http://www.rutschle.net/tech/sslh.shtml)
@@ -69,11 +69,11 @@ Services fournis
 * [Stunnel](https://www.stunnel.org/index.html)
   * Écoute et enveloppe les connexions OpenVPN. Cela les fait ressembler au trafic SSL standard et permet aux clients OpenVPN d'établir avec succès des tunnels même en présence d'une inspection approfondie des paquets.
   * Des profils unifiés pour les connexions OpenVPN enveloppées de stunnel sont générés à côté des profils de connexion directe. Des instructions détaillées sont également générées.
-  * Le certificat stunnel et la clé sont exportés au format PKCS # 12 afin qu'ils soient compatibles avec d'autres applications de tunneling SSL. Notamment, cela permet à [OpenVPN pour Androïde](https://play.google.com/store/apps/details?id=de.blinkt.openvpn&hl=fr) de tunneliser son trafic via [SSLDroid](https://play.google .com / store / apps / details? Id = hu.blint.ssldroid). OpenVPN en Chine sur un appareil mobile? Oui!
+  * Le certificat stunnel et la clé sont exportés au format PKCS # 12 afin qu'ils soient compatibles avec d'autres applications de tunneling SSL. Notamment, cela permet à [OpenVPN pour Android](https://play.google.com/store/apps/details?id=de.blinkt.openvpn&hl=fr) de tunneliser son trafic via [SSLDroid](https://play.google .com / store / apps / details? Id = hu.blint.ssldroid). OpenVPN en Chine sur un appareil mobile? Oui!
 * [Tor](https://www.torproject.org/)
   * Un [pont relais](https://www.torproject.org/docs/bridges) est mis en place avec un surnom aléatoire.
   * [Obfsproxy](https://www.torproject.org/projects/obfsproxy.html.en) est installé et configuré avec le support pour le transport enfichable obfs4.
-  * Un code BridgeQR est généré et peut être utilisé pour configurer automatiquement [Orbot](https://play.google.com/store/apps/details?id=org.torproject.android&hl=fr) pour Androïde.
+  * Un code BridgeQR est généré et peut être utilisé pour configurer automatiquement [Orbot](https://play.google.com/store/apps/details?id=org.torproject.android&hl=fr) pour Android.
 * [UFW](https://wiki.ubuntu.com/UncomplicatedFirewall)
   * Les règles de pare-feu sont configurées pour chaque service et tout trafic qui est envoyé vers un port non autorisé sera bloqué.
 * [unattended-upgrades](https://help.ubuntu.com/community/AutomaticSecurityUpdates)

--- a/playbooks/roles/l2tp-ipsec/templates/instructions-fr.md.j2
+++ b/playbooks/roles/l2tp-ipsec/templates/instructions-fr.md.j2
@@ -10,7 +10,7 @@ Si la connexion semble instable, vérifiez d'abord que les mots de passe ont ét
   * [Windows](#windows)
   * [macOS](#macos)
   * [Linux](#linux)
-  * [Androïde](#android)
+  * [Android](#android)
   * [iOS](#ios)
   * [Chromebook](#chromebook)
 
@@ -165,7 +165,7 @@ Les connexions L2TP / IPsec ne sont pas prises en charge sur la plupart des dist
     Mot de passe CHAP: {{ chap_password.stdout }}
 
 <a name="android"></a>
-### Androïde ###
+### Android ###
 1. Lancez l'application *Paramètres*.
 1. Appuyez *Plus...* dans la section *Sans fil et réseaux*.
 1. Tapez *VPN*.

--- a/playbooks/roles/openconnect/templates/instructions-fr.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions-fr.md.j2
@@ -9,11 +9,11 @@ OpenConnect est un serveur VPN extrêmement performant et léger qui offre une c
   * [Windows](#windows)
   * [macOS](#macos)
   * [Linux](#linux)
-  * [Androïde](#android)
+  * [Android](#android)
   * [iOS](#ios)
 
 <a name="clientcerts"></a>
-### Certificats du serveur et des clients (macOS, Androïde) ###
+### Certificats du serveur et des clients (macOS, Android) ###
 
 Les certificats clients sont un mécanisme par lequel les clients peuvent s'authentifier de manière sécurisée avec un serveur.
 
@@ -91,7 +91,7 @@ Les certificats clients sont un mécanisme par lequel les clients peuvent s'auth
 1. Vous devriez être prêt à partir! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
 <a name="android"></a>
-### Androïde ###
+### Android ###
 
 1. Téléchargez [Cisco AnyConnect](https://play.google.com/store/apps/details?id=com.cisco.anyconnect.vpn.android.avf&hl=fr) depuis Google Play.
 1. Lancez l'application.
@@ -116,12 +116,12 @@ Les certificats clients sont un mécanisme par lequel les clients peuvent s'auth
 1. Tapez *Détails* avertissement de securite est affiche when the Security Warning is displayed.
 1. Tapez *Import and Continue* sommaire du certificat est achhife when the Certificate Summary is displayed.
 1. Tapez *Se Connecter* dans l'écran de selection de groupe. Le défaut correct a déjà été choisi.
-1. Si c'est la première fois que vous utilisez AnyConnect, vous devrez accepter la boîte de dialogue de la demande de connexion affichée par Androïde.
+1. Si c'est la première fois que vous utilisez AnyConnect, vous devrez accepter la boîte de dialogue de la demande de connexion affichée par Android.
 1. Vous devriez être prêt à partir! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
 #### Avez-vous été demandé pour le nom d'utilisateur? ####
 
-Certains utilisateurs [ont signalé](https://github.com/StreisandEffect/streisand/issues/847) que leurs clients Androïde AnyConnect demandent un nom d'utilisateur et un mot de passe. C'est un bug connu que nous n'avons pas résolu. Voir la liste de [questions ouvertes Streisand AnyConnect](https://github.com/StreisandEffect/streisand/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20anyconnect). Si vous êtes affecté, vous pouvez nous aider à comprendre le bug en signalant vos informations en utilisant le modèle du bouton *New issue* de la liste des problèmes. Les correctifs sont également acceptés.
+Certains utilisateurs [ont signalé](https://github.com/StreisandEffect/streisand/issues/847) que leurs clients Android AnyConnect demandent un nom d'utilisateur et un mot de passe. C'est un bug connu que nous n'avons pas résolu. Voir la liste de [questions ouvertes Streisand AnyConnect](https://github.com/StreisandEffect/streisand/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20anyconnect). Si vous êtes affecté, vous pouvez nous aider à comprendre le bug en signalant vos informations en utilisant le modèle du bouton *New issue* de la liste des problèmes. Les correctifs sont également acceptés.
 
 Si vous êtes affecté, vous pouvez utiliser cette solution alternatif:
 

--- a/playbooks/roles/openvpn/templates/instructions-fr.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions-fr.md.j2
@@ -12,7 +12,7 @@ Pour des raisons de sécurité, les clients OpenVPN généralement ont leurs pro
   * [macOS](#macos)
   * [Linux](#linux)
   * [Linux (Ubuntu)](#linux-ubuntu)
-  * [Androïde](#android)
+  * [Android](#android)
   * [iOS](#ios)
 
 <a name="windows"></a>
@@ -134,8 +134,8 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
 1. Succès! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
 <a name="android"></a>
-### Androïde ###
-1. Installez [OpenVPN pour Androïde](https://play.google.com/store/apps/details?id=de.blinkt.openvpn&hl=fr).
+### Android ###
+1. Installez [OpenVPN pour Android](https://play.google.com/store/apps/details?id=de.blinkt.openvpn&hl=fr).
 1. Téléchargez l'un de ces profils OpenVPN unifiés:
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_direct_profile_filename }})
@@ -144,12 +144,12 @@ Il est préférable de configurer Ubuntu en utilisant le plugin OpenVPN pour Net
    * *[Profils UDP](#udp-profiles) sont disponibles.*
    * *[Profils combinés](#combined-profiles) sont maintenant disponibles.*
 1. Copiez le fichier `{{ openvpn_direct_profile_filename }}` sur votre téléphone.
-1. Lancez OpenVPN pour Androïde.
+1. Lancez OpenVPN pour Android.
 1. Appuyez sur l'icône du dossier en bas à droite de l'écran.
 1. Sélectionnez le profil `{{ openvpn_direct_profile_filename }}` que vous avez copié sur votre téléphone.
 1. Tapez sur l'icône de sauvegarde (disquette) en bas à droite de l'écran une fois l'importation est terminée.
 1. Tapez le profil.
-1. Acceptez l'avertissement de connexion VPN Androïde.
+1. Acceptez l'avertissement de connexion VPN Android.
 1. Succès! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
 <a name="ios"></a>

--- a/playbooks/roles/openvpn/templates/stunnel-instructions-fr.md.j2
+++ b/playbooks/roles/openvpn/templates/stunnel-instructions-fr.md.j2
@@ -13,7 +13,7 @@ Pour des raisons de sécurité, les clients OpenVPN ont généralement leurs pro
   * [Windows](#windows)
   * [macOS](#macos)
   * [Linux](#linux)
-  * [Androïde](#android)
+  * [Android](#android)
   * [iOS](#ios)
 
 <a name="windows"></a>
@@ -131,7 +131,7 @@ Maintenant, vous êtes prêt à installer OpenVPN et à le configurer pour achem
 Le plugin OpenVPN pour NetworkManager semble devenir très confus à la manière dont il doit acheminer le trafic lorsque vous vous connectez à un serveur OpenVPN via une connexion stunnel. L'ajout manuelle d'informations sur l'itinéraire ne semble pas aider. Par conséquent, contrairement aux [instructions non stunnel](/openvpn/index-fr.html), les étapes ci-dessus sont également la méthode de connexion recommandée pour Ubuntu.
 
 <a name="android"></a>
-### Androïde ###
+### Android ###
 #### Installation SSLDroid ####
 1. Téléchargez la clé PKCS #12 stunnel
    * [stunnel.p12](/openvpn/stunnel.p12)
@@ -149,18 +149,18 @@ Le plugin OpenVPN pour NetworkManager semble devenir très confus à la manière
 Maintenant, vous êtes prêt à installer OpenVPN pour Android et à le configurer pour acheminer son trafic via SSLDroid, qui est connecté au port Stunnel sur le serveur distant. Un profil .ovpn personnalisé qui est préconfiguré pour fonctionner avec SSLDroid rendra cela facile.
 
 ### Installation OpenVPN ###
-1. Installez [OpenVPN pour Androïde](https://play.google.com/store/apps/details?id=de.blinkt.openvpn&hl=fr).
+1. Installez [OpenVPN pour Android](https://play.google.com/store/apps/details?id=de.blinkt.openvpn&hl=fr).
 1. Téléchargez l'un de ces profils OpenVPN unifiés:
 {% for client in vpn_client_names.results %}
    * [{{ client.stdout }}](/openvpn/{{ client.stdout }}/{{ openvpn_stunnel_profile_filename }})
 {% endfor %}
 1. Copiez le fichier `{{ openvpn_stunnel_profile_filename }}` sur votre téléphone.
-1. Lancez OpenVPN pour Androïde.
+1. Lancez OpenVPN pour Android.
 1. Appuyez sur l'icône du dossier en bas à droite de l'écran.
 1. Sélectionnez le profil `{{ openvpn_stunnel_profile_filename }}` que vous avez copié sur votre téléphone.
 1. Tapez sur l'icône de sauvegarde (disquette) en bas à droite de l'écran une fois l'importation est terminée.
 1. Tapez le profil.
-1. Acceptez l'avertissement de connexion VPN Androïde.
+1. Acceptez l'avertissement de connexion VPN Android.
 1. Succès! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
 

--- a/playbooks/roles/shadowsocks/templates/instructions-fr.md.j2
+++ b/playbooks/roles/shadowsocks/templates/instructions-fr.md.j2
@@ -6,7 +6,7 @@ Shadowsocks
   * [Windows](#windows)
   * [macOS](#macos)
   * [Linux](#linux)
-  * [Androïde](#android)
+  * [Android](#android)
   * [iOS](#ios)
 * Plugins
   * [simple-obfs](#simple-obfs)
@@ -86,8 +86,8 @@ Une fois que vous avez Shadowsocks fonctionnant localement, vous devrez transfé
 
 
 <a name="android"></a>
-### Androïde ###
-1. Téléchargez Shadowsocks pour Androïde à partir de [Google Play](https://play.google.com/store/apps/details?id=com.github.shadowsocks&hl=fr). Si Google Play est bloqué dans votre pays, vous pouvez [télécharger une copie en miroir](/mirror/shadowsocks/index-fr.html) de ce serveur!
+### Android ###
+1. Téléchargez Shadowsocks pour Android à partir de [Google Play](https://play.google.com/store/apps/details?id=com.github.shadowsocks&hl=fr). Si Google Play est bloqué dans votre pays, vous pouvez [télécharger une copie en miroir](/mirror/shadowsocks/index-fr.html) de ce serveur!
 1. Lancez l'application.
 1. Tapez sur l'icône Ajouter un profil +, en haut à droite de l'écran.
 1. Tapez l'icône *+* en bas à droite.
@@ -96,7 +96,7 @@ Une fois que vous avez Shadowsocks fonctionnant localement, vous devrez transfé
 
    ![Shadowsocks QR code](/shadowsocks/shadowsocks-qr-code.png)
 1. Tapez sur l'icône de l'avion en haut.
-1. Acceptez l'avertissement de connexion VPN Androïde.
+1. Acceptez l'avertissement de connexion VPN Android.
 1. Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
 
@@ -124,4 +124,4 @@ Pour les utilisateurs sur des réseaux peu fiables ou hostiles (en particulier l
         Encryption Method: {{ shadowsocks_encryption_method }}
         Plugin: {{ shadowsocks_client_obfs_plugin }}
         Plugin_Options: {{ shadowsocks_obfs_client_plugin_opts }}
-Les utilisateurs d'Androïde devront d'abord télécharger l'application [Simple obfuscation] (https://play.google.com/store/apps/details?id=com.github.shadowsocks.plugin.obfs_local&hl=fr), puis modifier le profil existant de Streisand sur votre client pour utiliser ce plugin. Vous pouvez le faire en appuyant sur le bouton d'édition (edit) à côté du profil, en tapant l'option Plugin en bas du profil et en sélectionnant le plugin "Simple obfuscation" dans le menu. Votre trafic Shadowsocks sera maintenant obscurci en tant que {{shadowsocks_obfs_cover_protocol}} trafic vers {{shadowsocks_obfs_cover_domain}}.
+Les utilisateurs d'Android devront d'abord télécharger l'application [Simple obfuscation] (https://play.google.com/store/apps/details?id=com.github.shadowsocks.plugin.obfs_local&hl=fr), puis modifier le profil existant de Streisand sur votre client pour utiliser ce plugin. Vous pouvez le faire en appuyant sur le bouton d'édition (edit) à côté du profil, en tapant l'option Plugin en bas du profil et en sélectionnant le plugin "Simple obfuscation" dans le menu. Votre trafic Shadowsocks sera maintenant obscurci en tant que {{shadowsocks_obfs_cover_protocol}} trafic vers {{shadowsocks_obfs_cover_domain}}.

--- a/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
@@ -6,7 +6,7 @@ Tunnel SSH
   * [Windows](#windows)
   * [Linux et macOS](#linux-and-macos)
 {% if streisand_tinyproxy_enabled %}
-  * [Androïde](#android)
+  * [Android](#android)
 {% endif %}
   * [Notes](#notes)
 
@@ -122,7 +122,7 @@ Sshuttle est une simple solution de tunneling VPN qui fonctionne sur le transpor
 
 {% if streisand_tinyproxy_enabled %}
 <a name="android"></a>
-### Androïde ###
+### Android ###
 1. Installez [SSH persistent tunnels](https://play.google.com/store/apps/details?id=org.ayal.SPT&hl=fr) par Shai Ayal. Cette application permet de transférer facilement plusieurs ports via un tunnel SSH, et fonctionne assez bien pour s'assurer que les tunnels restent actifs même lorsque vous changez régulièrement entre LTE, 3G et WiFi. L'application est [open source](https://bitbucket.org/ayal_org/ssh-persistent-tunnel/) et peut être compilée gratuitement, mais la version Play Store coûte $1,50 (USD).
 1. Téléchargez la clé privée `streisand_rsa` qui sert à authentifier la connexion SSH:
    * [streisand\_rsa](/ssh/streisand_rsa)
@@ -159,7 +159,7 @@ Ces étapes ne fonctionneront que si vous êtes connecté via WiFi. Ils doivent 
 8. Tapez *Port du proxy* et saisissez `8888`.
 9. Tapez *Enregistrer*.
 
-Certaines applications vous permettent de rendre ces paramètres persistants pour tous les réseaux. Twitter pour Androïde et Firefox pour Androïde peut acheminer son trafic via le tunnel SPT SSH indépendamment de votre connexion actuelle (WiFi, 3G, HSPA +, LTE, etc.).
+Certaines applications vous permettent de rendre ces paramètres persistants pour tous les réseaux. Twitter pour Android et Firefox pour Android peut acheminer son trafic via le tunnel SPT SSH indépendamment de votre connexion actuelle (WiFi, 3G, HSPA +, LTE, etc.).
 
 #### Configuration de Twitter pour Android pour utiliser SPT ####
 1. Ouvrez Twitter.

--- a/playbooks/roles/streisand-gateway/templates/instructions-fr.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/instructions-fr.md.j2
@@ -17,7 +17,7 @@ Ce document couvre les instructions d'installation du certificat SSL et vous mon
 * [Installation du certificat SSL](#ssl)
   * [Windows](#ssl-windows)
   * [macOS](#ssl-macos)
-  * [Androïde](#ssl-android)
+  * [Android](#ssl-android)
   * [iOS](#ssl-ios)
   * [Chromium](#ssl-chromium)
   * [Firefox](#ssl-firefox)
@@ -70,22 +70,22 @@ Ces instructions fonctionnent pour Chrome et Safari. Firefox utilise son propre 
 
 
 <a name="ssl-android"></a>
-### Androïde ###
+### Android ###
 Ces instructions fonctionnent pour Chrome Firefox pour Android utilise son propre gestionnaire de certificats interne mais ne fournit pas d'interface pour l'importation de certificats. Chrome est donc la manière recommandée de se connecter à la passerelle Streisand.
 
 #### Moins sécurisé, mais facile ####
 
 1. [Téléchargez le certificat SSL](#download) intégré dans ce document.
-1. Envoyez le certificat téléchargé par courrier électronique à un compte auquel vous pouvez accéder à partir de l'appareil Androïde.
+1. Envoyez le certificat téléchargé par courrier électronique à un compte auquel vous pouvez accéder à partir de l'appareil Android.
 1. Ouvrez l'e-mail, puis appuyez sur la pièce jointe.
 1. Une invite apparaîtra, entez `{{ streisand_server_name }}` pour le *Nom du certificat*, et assurez-vous que *VPN et applications* est sélectionné pour la valeur de *Utilisation du certificat*.
 1. Tapez *OK*.
 1. Vous êtes prêt à vous connecter. Voir [Connexion à votre passerelle Streisand](#connecting-ssl).
 
 #### Plus sécurisé ####
-1. Connectez l'appareil Androïde à votre ordinateur.
+1. Connectez l'appareil Android à votre ordinateur.
 1. [Téléchargez le certificat SSL](#download) intégré dans ce document.
-1. Faites glisser le certificat téléchargé vers la racine du système de fichiers de l'appareil Androïde.
+1. Faites glisser le certificat téléchargé vers la racine du système de fichiers de l'appareil Android.
 1. Lancez l'application *Paramètres*.
 1. Faites défiler jusqu'à la section *Appareil* et tapez sur *Sécurité*.
 1. Faites défiler jusqu'à la section *Stockage des identifiants* et tapez *Installer depuis la carte SD*.

--- a/playbooks/roles/tor-bridge/templates/instructions-fr.md.j2
+++ b/playbooks/roles/tor-bridge/templates/instructions-fr.md.j2
@@ -4,7 +4,7 @@ Pont Tor
 ---
 * Plateformes
   * [Ordinateurs de bureau](#desktops)
-  * [Androïde](#android)
+  * [Android](#android)
   * [iOS](#ios)
 
 <a name="desktops"></a>
@@ -22,7 +22,7 @@ Pont Tor
 Vous êtes prêt à partir! Tor est connecté au serveur de pont *{{ tor_bridge_nickname.stdout }}*, et votre trafic Tor crypté est totalement obscurci par obfsproxy afin qu'il ne ressemble pas au trafic Tor!
 
 <a name="android"></a>
-### Androïde ###
+### Android ###
 1. Téléchargez [Orbot](https://play.google.com/store/apps/details?id=org.torproject.android&hl=fr) et lancez-le.
 1. Tapez le bouton *Menu*.
 1. Tapdz *QR Codes*.
@@ -46,7 +46,7 @@ Vous êtes maintenant prêt à configurer Twitter et Firefox pour acheminer leur
 1. Tapez *Hôte du proxy* et entrez `127.0.0.1`.
 1. Tapez *Port du proxy* et entrez `8118`.
 
-#### Configuration de Firefox pour Androïde pour utiliser Orbot ####
+#### Configuration de Firefox pour Android pour utiliser Orbot ####
 1. Ouvrez Firefox.
 2. Tapez `about:config` dans la barre d'adresse et appuyez sur le bouton 'Go' de votre clavier.
 3. Tapez `proxy` dans la barre de recherche.


### PR DESCRIPTION
I just rename all ```Androïde``` to ```Android``` (s/Androïde/Android), because it's a brand.
With this commit, #1195 keeps consistency.