### PR TITLE
Update README to use https

### DIFF
--- a/README-chs.md
+++ b/README-chs.md
@@ -45,25 +45,25 @@ Streisand介绍
   * Windows, macOS, Android 和 iOS 用户可以使用系统自带的 VPN 进行设置、连接，而不需要另外下载第三方的软件来实现。
 * [Monit](https://mmonit.com/monit/)
   * 能够监视、处理运行状态，针对那些奔溃的进程或者没有响应的进程进行自动重启和维护。
-* [OpenSSH](http://www.openssh.com/)
+* [OpenSSH](https://www.openssh.com/)
   * 支持 Windows 和 Android 的 SSH 隧道， 并且需要使用 PuTTY 将默认的密钥对导出成 .ppk 的格式；
   * [Tinyproxy](https://banu.com/tinyproxy/) 默认安装并绑定到主机，它作为一个 http(s) 代理提供给那些原生不支持 SOCKS 代理的软件通过 SSH 隧道访问网络，比如说 Android 上的鸟嘀咕。
   * 针对 [sshuttle](https://github.com/sshuttle/sshuttle) 的一个无特权转发用户和产生的 SSH 密钥对，同样也兼容 SOCKS；
-* [OpenConnect](http://www.infradead.org/ocserv/index.html) / [Cisco AnyConnect](http://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
+* [OpenConnect](https://ocserv.gitlab.io/www/index.html) / [Cisco AnyConnect](https://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
   * oepnConnect (ocserv) 是一个非常强劲、轻巧的 VPN 服务器，并且完全兼容思科的 AnyConnect 客户端；
-  * 其中包涵了很多顶级的标准[协议](http://www.infradead.org/ocserv/technical.html)，比如：HTTP, TLS 和 DTLS， 当然还有很多被跨国公司广泛使用的且流行的技术；
+  * 其中包涵了很多顶级的标准[协议](https://ocserv.gitlab.io/www/technical.html)，比如：HTTP, TLS 和 DTLS， 当然还有很多被跨国公司广泛使用的且流行的技术；
    * 这就意味着 OpenConnect 非常易用且高速，而且经得住审查的考验，几乎从未被封锁。
 * [OpenVPN](https://openvpn.net/index.php/open-source.html)
   * 从自带的 .ovpn 配置文件生成一个简单的客户端配置文件；
   * 同时支持 TCP 和 UDP 连接；
   * 客户端的 DNS 解析由 [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) 负责，避免 DNS 泄露；
   * 启用 TLS 认证，有助于防止主动探测攻击。错误的 HMAC 流量并不会被轻易丢弃。
-* [Shadowsocks](http://shadowsocks.org/en/index.html)
+* [Shadowsocks](https://shadowsocks.org/en/index.html)
   * 安装的是高性能的 libev 版本，这个版本能够处理数以千计的并发连接；
   * Android 和 iOS 只需要扫描一个二维码就能完成自动配置。DNS 可以设置为 8.8.8.8，或者将配置一一复制粘贴到客户端上；
   * 采用 ChaCha20 和 Poly1305 对 [AEAD](https://shadowsocks.org/en/spec/AEAD-Ciphers.html) 进行加密，增强了安全性并提升了穿透性；
   * 使用 [simple-obfs](https://github.com/shadowsocks/simple-obfs) 插件提供流量混淆以便于从审查的网络中脱逃（尤其是QOS节流中）。
-* [sslh](http://www.rutschle.net/tech/sslh.shtml)
+* [sslh](https://www.rutschle.net/tech/sslh/README.html)
   * sslh 是一个协议解复用器（这个我不了解，如果有更好的翻译请request），在一个高度限制的网络环境下（只能访问 http 端口的网络为例），它作为一种备选方案，仍然可以通过 OpenSSH 和 OpenVPN 进行连接，因为通过 sslh 让二者共享了 443 端口。
 * [Stunnel](https://www.stunnel.org/index.html)
   * 监听并且将 OpenVPN 的流量进行封装，让 OpenVPN 的流量伪装成标注的 SSL 流量，从而可以让 OpenVPN 客户端成功通过隧道进行连接，躲避深度包检测。
@@ -85,7 +85,7 @@ Streisand介绍
 在你搞事情之前，认真阅读
 
 ### 重要说明 ###
-Streisand 基于 [Ansible](http://www.ansible.com/home) ，它可以在远程服务器完成自动配置、打包等工作，Streisand 是将远程服务器自动配置成为多个 VPN 服务及科学上网的工具。
+Streisand 基于 [Ansible](https://www.ansible.com/) ，它可以在远程服务器完成自动配置、打包等工作，Streisand 是将远程服务器自动配置成为多个 VPN 服务及科学上网的工具。
 
 Streisand 运行在**你自己的计算机上时（或者你电脑的虚拟机上时）**，它将把网关部署到你 VPS 提供商的**另一个服务器**上（通过你自己的API自动生成）。另外，如果 Streisand 运行在 VPS 上，它将会把网关部署到**另一个 VPS 上**，所以说原先你运行 Streisand 的那个 VPS 就多余了，记得部署完成并获得文档后把它删掉，而部署出来的那个 VPS 你是无法使用 SSH 连接进去的，除非你有公钥（当然这是不可能的，因为整个配置过程都没有提供公钥给你下载或者你想办法把它搞出来）。
 
@@ -107,7 +107,7 @@ Streisand 运行在**你自己的计算机上时（或者你电脑的虚拟机�
   * 在 Fedora
 
         sudo dnf install git
-  * 在 macOS 上 （需要通过 [Homebrew](http://brew.sh/) 进行安装）
+  * 在 macOS 上 （需要通过 [Homebrew](https://brew.sh/) 进行安装）
 
         brew install git
 * 利用 Python 安装 [pip](https://pip.pypa.io/en/latest/) 包管理
@@ -122,7 +122,7 @@ Streisand 运行在**你自己的计算机上时（或者你电脑的虚拟机�
         sudo easy_install pip
         sudo pip install pycurl
 
-* 安装 [Ansible](http://www.ansible.com/home) 。
+* 安装 [Ansible](https://www.ansible.com/) 。
   * 在 macOS 上
 
         brew install ansible
@@ -228,4 +228,4 @@ Streisand 运行在**你自己的计算机上时（或者你电脑的虚拟机�
 
 非常感谢 [Paul Wouters](https://nohats.ca/) 的 [The Libreswan Project](https://libreswan.org/) ，正是他的耐心调试和设置，才让 L2TP/IPsec 工作的那么好。
 
-另外，[Joshua Lund](https://github.com/jlund)开始这个项目工作的时候，他差不多把 [Starcadian's](http://starcadian.com/) 的 'Sunset Blood' 听了300遍（译者：这张专辑节奏感不错）。
+另外，[Joshua Lund](https://github.com/jlund)开始这个项目工作的时候，他差不多把 [Starcadian's](https://www.starcadian.com/) 的 'Sunset Blood' 听了300遍（译者：这张专辑节奏感不错）。

--- a/README-fr.md
+++ b/README-fr.md
@@ -46,25 +46,25 @@ Services fournis
   * Les utilisateurs Windows, macOS, Android et iOS peuvent tous se connecter en utilisant le support VPN natif intégré à chaque système d'exploitation sans installer de logiciel supplémentaire.
 * [Monit](https://mmonit.com/monit/)
   * Surveille la santé du processus et redémarre automatiquement les services dans le cas improbable où ils se plante ou ne répondent pas.
-* [OpenSSH](http://www.openssh.com/)
+* [OpenSSH](https://www.openssh.com/)
   * Les tunnels Windows et Android SSH sont également pris en charge et une copie des clés sont exportée dans le format .ppk que PuTTY requiert.
   * [Tinyproxy](https://banu.com/tinyproxy/) est installé et lié à localhost. Il peut être accédé sur un tunnel SSH par des programmes qui ne prennent pas en charge nativement SOCKS et qui nécessitent un proxy HTTP, comme Twitter pour Android.
   * Un utilisateur de transfert non privilégié et une paire paire de clés asymétriques SSH sont générés pour les fonctionnalités [sshuttle](https://github.com/sshuttle/sshuttle) et SOCKS.
-* [OpenConnect](http://www.infradead.org/ocserv/index.html)/[Cisco AnyConnect](http://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
+* [OpenConnect](https://ocserv.gitlab.io/www/index.html)/[Cisco AnyConnect](https://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
   * OpenConnect (ocserv) est un serveur VPN extrêmement performant et léger qui offre également une compatibilité totale avec les clients officiels Cisco AnyConnect.
-  * Le [protocole](http://www.infradead.org/ocserv/technical.html) est bâti sur des standards comme HTTP, TLS et DTLS, et c'est l'une des technologies VPN les plus populaires et largement utilisées parmi des grands entreprises multi-nationales.
+  * Le [protocole](https://ocserv.gitlab.io/www/technical.html) est bâti sur des standards comme HTTP, TLS et DTLS, et c'est l'une des technologies VPN les plus populaires et largement utilisées parmi des grands entreprises multi-nationales.
     * Cela signifie qu'en plus de sa facilité d'utilisation et de sa rapidité, OpenConnect est également très résistant à la censure et presque jamais bloqué.
 * [OpenVPN](https://openvpn.net/index.php/open-source.html)
   * Des profils autonome "unifiés" .ovpn sont générés pour une configuration de client facile en utilisant un seul fichier.
   * Les connexions TCP et UDP sont prises en charge.
   * La résolution DNS du client est gérée via [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) pour empêcher les fuites DNS.
   * L'authentification TLS est activée, ce qui permet de vous protéger contre les attaques actives. Le trafic qui n'a pas de HMAC approprié est simplement abandonné.
-* [Shadowsocks](http://shadowsocks.org/en/index.html)
+* [Shadowsocks](https://shadowsocks.org/en/index.html)
   * La [variante libev](https://github.com/shadowsocks/shadowsocks-libev) haute performance est installée. Cette version est capable de gérer des milliers de connexions simultanées.
   * Un code QR est généré qui peut être utilisé pour configurer automatiquement les clients Android et iOS en prenant simplement une photo. Vous pouvez étiqueter "8.8.8.8" sur ce mur de béton, ou vous pouvez coller les instructions de Shadowsocks et quelques codes QR à la place!
   * [AEAD](https://shadowsocks.org/fr/spec/AEAD-Ciphers.html) est activé avec ChaCha20 et Poly1305 pour un contournement plus efficace du GFW.
   * Le plugin [simple-obfs](https://github.com/shadowsocks/simple-obfs) est installé afin de fournir une techique d'évasion du votre trafic sur des réseaux hostiles (en particulier ceux qui appliquent la limitation de la qualité de service (QOS)).
-* [sslh](http://www.rutschle.net/tech/sslh.shtml)
+* [sslh](https://www.rutschle.net/tech/sslh/README.html)
   * Sslh est un démultiplexeur de protocole qui permet à Nginx, OpenSSH et OpenVPN de partager le port 443. Cela fournit une autre option de connexion et signifie que vous pouvez toujours acheminer le trafic via OpenSSH et OpenVPN même si vous êtes sur un réseau restrictif qui bloque tout accès à des ports non HTTP.
 * [Stunnel](https://www.stunnel.org/index.html)
   * Écoute et enveloppe les connexions OpenVPN. Cela les fait ressembler au trafic SSL standard et permet aux clients OpenVPN d'établir avec succès des tunnels même en présence d'une inspection approfondie des paquets.
@@ -86,7 +86,7 @@ Installation
 Veuillez lire *attentivement* toutes les instructions d'installation avant de poursuivre.
 
 ### Clarification importante ###
-Streisand est basé sur [Ansible](http://www.ansible.com/home), un outil d'automatisation qui est généralement utilisé pour fournir et configurer des fichiers et des paquets sur des serveurs distants. Cela signifie que lorsque vous exécutez Streisand, il configure automatiquement **un autre serveur distant** avec les paquets VPN et ses configurations.
+Streisand est basé sur [Ansible](https://www.ansible.com/), un outil d'automatisation qui est généralement utilisé pour fournir et configurer des fichiers et des paquets sur des serveurs distants. Cela signifie que lorsque vous exécutez Streisand, il configure automatiquement **un autre serveur distant** avec les paquets VPN et ses configurations.
 
 Streisand va déployer **un autre serveur** sur votre fournisseur d'hébergement choisi lorsque vous exécutez **sur votre ordinateur local** (par exemple, votre ordinateur portable). Habituellement, vous **n'utilisez pas Streisand sur le serveur distant** car, par défaut, cela entraînerait le déploiement d'un autre serveur à partir de votre serveur et rendrait le premier serveur redondant (Ouf!).
 
@@ -114,7 +114,7 @@ Effectuez toutes ces tâches sur votre machine locale.
   * Sur Fedora
 
             sudo yum install git
-  * Sur macOS (via [Homebrew](http://brew.sh/))
+  * Sur macOS (via [Homebrew](https://brew.sh/))
 
             brew install git
 * Installez le système de gestion de paquets [pip](https://pip.pypa.io/en/latest/) pour Python.
@@ -129,8 +129,8 @@ Effectuez toutes ces tâches sur votre machine locale.
             sudo easy_install pip
             sudo pip install pycurl
 
-* Installez [Ansible](http://www.ansible.com/home).
-  * Sur macOS (via [Homebrew](http://brew.sh/))
+* Installez [Ansible](https://www.ansible.com/).
+  * Sur macOS (via [Homebrew](https://brew.sh/))
 
             brew install ansible
   * Sur BSD ou Linux (via pip)
@@ -234,4 +234,4 @@ Nous sommes reconnaissants à [Trevor Smith](https://github.com/trevorsmith) pou
 
 Un grand merci à [Paul Wouters](https://nohats.ca/) de [The Libreswan Projet](https://libreswan.org/) à son aide généreuse pour le débogage des configurations d'L2TP/IPsec.
 
-L'album 'Sunset Blood' de [Starcadian](http://starcadian.com/) a été répété environ 300 fois au cours des premiers mois de travail sur le projet au début de 2014.
+L'album 'Sunset Blood' de [Starcadian](https://starcadian.com/) a été répété environ 300 fois au cours des premiers mois de travail sur le projet au début de 2014.

--- a/README-ru.md
+++ b/README-ru.md
@@ -46,24 +46,24 @@
   * Пользователи Windows, macOS, Android, и iOS  могут подключаться с использованием встроенной поддержки VPN без установки дополнительного ПО.
 * [Monit](https://mmonit.com/monit/)
   * Отслеживает здоровье процессов и автоматически перезапускает их , если они падают или зависают.
-* [OpenSSH](http://www.openssh.com/)
+* [OpenSSH](https://www.openssh.com/)
   * Создается непривилегированный пользователь и пара ключей для [sshuttle](https://github.com/sshuttle/sshuttle) и SOCKS.
   * Поддерживаются также SSH-туннели Windows и Android, создается копия пары ключей в .ppk формате для PuTTY
   * Установлен [Tinyproxy](https://banu.com/tinyproxy/) и подключен к localhost. Программы, которые не поддерживают SOCKS и требуют наличия HTTP proxy, такие как Twitter для Android, могу подключиться к нему через SSH-туннель.
-* [OpenConnect](http://www.infradead.org/ocserv/index.html) / [Cisco AnyConnect](http://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
+* [OpenConnect](https://ocserv.gitlab.io/www/index.html) / [Cisco AnyConnect](https://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
   * OpenConnect (ocserv) - высокопроизводительный и легковесный VPN-сервер полностью совместимый с официальными клиентами Cisco AnyConnect.
-  * Его [протокол](http://www.infradead.org/ocserv/technical.html) построен на классических стандартах, таких как HTTP, TLS и  DTLS и является одним из самых популярных и широко используемых мультинациональными корпорациями VPN технологий.
+  * Его [протокол](https://ocserv.gitlab.io/www/technical.html) построен на классических стандартах, таких как HTTP, TLS и  DTLS и является одним из самых популярных и широко используемых мультинациональными корпорациями VPN технологий.
     * Это означает, что кроме своей простоты и скорости, OpenConnect также устойчив к цензуре и практически никогда не блокируется.
 * [OpenVPN](https://openvpn.net/index.php/open-source.html)
   * Для каждого клиента создаются унифицированные .ovpn профили для простой настройки клиента с использованием только одного файла.
   * Поддерживаются соединения TCP и UDP.
   * Определение адресов для клиента исползует [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) для предотвращения утечек DNS-запросов.
    *  Включена TLS Authentication для защиты от зондирующих атак. Трафик не имеющий корректного HMAC будет попросту проигнорирован.
-* [Shadowsocks](http://shadowsocks.org/en/index.html)
+* [Shadowsocks](https://shadowsocks.org/en/index.html)
   * Установлен высокопроизводительный [вариант libev](https://github.com/shadowsocks/shadowsocks-libev). Эта версия обрабатывает тысячи одновременных соединений.
   * Создается QR код который можно использовать для автоматической настройки Android и iOS клиентов. Вы можете написать '8.8.8.8' на бетонной стене, или вы можете наклеить инструкции для Shadowsocks и QR коды на ту же стену.
   * Включена поддержка [AEAD](https://shadowsocks.org/en/spec/AEAD-Ciphers.html) с ChaCha20 и Poly1305 для усиленной безопасности и уклонения от GFW.
-* [sslh](http://www.rutschle.net/tech/sslh.shtml)
+* [sslh](https://www.rutschle.net/tech/sslh/README.html)
   * Sslh - демультиплексор протоколов, позволяющий Nginx, OpenSSH и  OpenVPN совместно использовать порт 443. Это предоставляет альтернативный метод подключения и означает, что вы можете перенаправлять трафик через OpenSSH и OpenVPN даже если вы находитесь в сети с очень строгими правилами, которая блокирует все соединения не с HTTP.
 * [Stunnel](https://www.stunnel.org/index.html)
   * Слушает и упаковывает соединения OpenVPN. Это заставляет их выглядеть как стандартный SSL трафик и позволяет OpenVPN клиентам устанавливать туннели даже в случае использования Deep Packet Inspection.
@@ -85,7 +85,7 @@
 Пожалуйста **внимательно** прочитайте инструкции по установке перед тем, как продолжать.
 
 ### Важное разъяснение ###
-Стрейзанд основан на [Ansible](http://www.ansible.com/home), инструменте автоматизации, который обычно используется для установки и настройки файлов и пакетов на удалённых серверах. Стрейзанд автоматически создает **новый удалённый сервер** с пакетами и конфигурационными файлами VPN.
+Стрейзанд основан на [Ansible](https://www.ansible.com/), инструменте автоматизации, который обычно используется для установки и настройки файлов и пакетов на удалённых серверах. Стрейзанд автоматически создает **новый удалённый сервер** с пакетами и конфигурационными файлами VPN.
 
 Когда вы запустите Стрейзанд **на вашей домашней машине** (например на вашем лэптопе), он создаст и запустит **новый отдельный сервер** у хостера по вашему выбору. Обычно, вам **не надо запускать Стрейзанд на удалённом сервере** , так как по умолчанию это приведет к созданию нового сервера с вашего текущего сервера и первый сервер будет излишним.  (фух!).
 
@@ -107,7 +107,7 @@
   * На Fedora
 
         sudo yum install git
-  * На macOS (с использованием [Homebrew](http://brew.sh/))
+  * На macOS (с использованием [Homebrew](https://brew.sh/))
 
         brew install git
 * Установите  [pip](https://pip.pypa.io/en/latest/) - систему управления пакетами для Python.
@@ -122,7 +122,7 @@
         sudo easy_install pip
         sudo pip install pycurl
 
-* Установите [Ansible](http://www.ansible.com/home).
+* Установите [Ansible](https://www.ansible.com/).
   * На macOS (с использованием [Homebrew](http://brew.sh/))
 
         brew install ansible
@@ -203,4 +203,4 @@
 
 Огромное спасибо  [Paul Wouters](https://nohats.ca/) из [The Libreswan Project](https://libreswan.org/) за его великодушную помощь в отладке инсталляции  L2TP/IPsec.
 
-Альбом 'Sunset Blood' группы [Starcadian's](http://starcadian.com/) был прослушан примерно 300 раз в цикле в течение первых месяцев работы над этим проектом в начале 2014 года.
+Альбом 'Sunset Blood' группы [Starcadian's](https://www.starcadian.com/) был прослушан примерно 300 раз в цикле в течение первых месяцев работы над этим проектом в начале 2014 года.

--- a/README.md
+++ b/README.md
@@ -46,25 +46,25 @@ Services Provided
   * Windows, macOS, Android, and iOS users can all connect using the native VPN support that is built into each operating system without installing any additional software.
 * [Monit](https://mmonit.com/monit/)
   * Monitors process health and automatically restarts services in the unlikely event that they crash or become unresponsive.
-* [OpenSSH](http://www.openssh.com/)
+* [OpenSSH](https://www.openssh.com/)
   * Windows and Android SSH tunnels are also supported, and a copy of the keypair is exported in the .ppk format that PuTTY requires.
   * [Tinyproxy](https://banu.com/tinyproxy/) is installed and bound to localhost. It can be accessed over an SSH tunnel by programs that do not natively support SOCKS and that require an HTTP proxy, such as Twitter for Android.
   * An unprivileged forwarding user and SSH keypair are generated for [sshuttle](https://github.com/sshuttle/sshuttle) and SOCKS capabilities.
-* [OpenConnect](http://www.infradead.org/ocserv/index.html) / [Cisco AnyConnect](http://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
+* [OpenConnect](https://ocserv.gitlab.io/www/index.html) / [Cisco AnyConnect](https://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)
   * OpenConnect (ocserv) is an extremely high-performance and lightweight VPN server that also features full compatibility with the official Cisco AnyConnect clients.
-  * The [protocol](http://www.infradead.org/ocserv/technical.html) is built on top of standards like HTTP, TLS, and DTLS, and it's one of the most popular and widely used VPN technologies among large multi-national corporations.
+  * The [protocol](https://ocserv.gitlab.io/www/technical.html) is built on top of standards like HTTP, TLS, and DTLS, and it's one of the most popular and widely used VPN technologies among large multi-national corporations.
     * This means that in addition to its ease-of-use and speed, OpenConnect is also highly resistant to censorship and is almost never blocked.
 * [OpenVPN](https://openvpn.net/index.php/open-source.html)
   * Self-contained "unified" .ovpn profiles are generated for easy client configuration using only a single file.
   * Both TCP and UDP connections are supported.
   * Client DNS resolution is handled via [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) to prevent DNS leaks.
   * TLS Authentication is enabled which helps protect against active probing attacks. Traffic that does not have the proper HMAC is simply dropped.
-* [Shadowsocks](http://shadowsocks.org/en/index.html)
+* [Shadowsocks](https://shadowsocks.org/en/index.html)
   * The high-performance [libev variant](https://github.com/shadowsocks/shadowsocks-libev) is installed. This version is capable of handling thousands of simultaneous connections.
   * A QR code is generated that can be used to automatically configure the Android and iOS clients by simply taking a picture. You can tag '8.8.8.8' on that concrete wall, or you can glue the Shadowsocks instructions and some QR codes to it instead!
   * [AEAD](https://shadowsocks.org/en/spec/AEAD-Ciphers.html) support is enabled using ChaCha20 and Poly1305 for enhanced security and improved GFW evasion.
   * The [simple-obfs](https://github.com/shadowsocks/simple-obfs) plugin is installed to provide robust traffic evasion on hostile networks (especially those implementing quality of service (QOS) throttling).
-* [sslh](http://www.rutschle.net/tech/sslh.shtml)
+* [sslh](https://www.rutschle.net/tech/sslh/README.html)
   * Sslh is a protocol demultiplexer that allows Nginx, OpenSSH, and OpenVPN to share port 443. This provides an alternative connection option and means that you can still route traffic via OpenSSH and OpenVPN even if you are on a restrictive network that blocks all access to non-HTTP ports.
 * [Stunnel](https://www.stunnel.org/index.html)
   * Listens for and wraps OpenVPN connections. This makes them look like standard SSL traffic and allows OpenVPN clients to successfully establish tunnels even in the presence of Deep Packet Inspection.
@@ -86,7 +86,7 @@ Installation
 Please read all installation instructions **carefully** before proceeding.
 
 ### Important Clarification ###
-Streisand is based on [Ansible](http://www.ansible.com/home), an automation tool that is typically used to provision and configure files and packages on remote servers. Streisand automatically sets up **another remote server** with the VPN packages and configuration.
+Streisand is based on [Ansible](https://www.ansible.com/), an automation tool that is typically used to provision and configure files and packages on remote servers. Streisand automatically sets up **another remote server** with the VPN packages and configuration.
 
 Streisand will spin up and deploy **another server** on your chosen hosting provider when you run **on your home machine** (e.g. your laptop). Usually, you **do not run Streisand on the remote server** as by default this would result in the deployment of another server from your server and render the first server redundant (whew!).
 
@@ -114,7 +114,7 @@ Complete all of these tasks on your local home machine.
   * On Fedora
 
         sudo yum install git
-  * On macOS (via [Homebrew](http://brew.sh/))
+  * On macOS (via [Homebrew](https://brew.sh/))
 
         brew install git
 * Install the [pip](https://pip.pypa.io/en/latest/) package management system for Python.
@@ -129,8 +129,8 @@ Complete all of these tasks on your local home machine.
         sudo easy_install pip
         sudo pip install pycurl
 
-* Install [Ansible](http://www.ansible.com/home).
-  * On macOS (via [Homebrew](http://brew.sh/))
+* Install [Ansible](https://www.ansible.com/).
+  * On macOS (via [Homebrew](https://brew.sh/))
 
         brew install ansible
   * On BSD or Linux (via pip)
@@ -240,4 +240,4 @@ We are grateful to [Trevor Smith](https://github.com/trevorsmith) for his massiv
 
 Huge thanks to [Paul Wouters](https://nohats.ca/) of [The Libreswan Project](https://libreswan.org/) for his generous help troubleshooting the L2TP/IPsec setup.
 
-[Starcadian's](http://starcadian.com/) 'Sunset Blood' album was played on repeat approximately 300 times during the first few months of work on the project in early 2014.
+[Starcadian's](https://www.starcadian.com/) 'Sunset Blood' album was played on repeat approximately 300 times during the first few months of work on the project in early 2014.


### PR DESCRIPTION
Unfortunately, http://www.thekelleys.org.uk/ had no https alternative

Some URLs now redirect to different ones. For example:
http://www.infradead.org/ocserv/index.html redirected to https://ocserv.gitlab.io/www/index.html