### PR TITLE
Clean up pkcs12 locations 

### DIFF
--- a/playbooks/roles/certificates/tasks/pkcs.yml
+++ b/playbooks/roles/certificates/tasks/pkcs.yml
@@ -1,8 +1,8 @@
 ---
 - name: "Generate a random password that will be used during the PKCS #12 conversion"
-  shell: "{{ streisand_word_gen.weak_password }} > {{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
+  shell: "{{ streisand_word_gen.weak_password }} > {{ tls_client_path }}/{{ client_name.stdout }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
   args:
-    creates: "{{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
+    creates: "{{ tls_client_path }}/{{ client_name.stdout }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
   with_items: "{{ vpn_client_names.results }}"
   loop_control:
     loop_var: "client_name"
@@ -10,7 +10,7 @@
 
 - name: "Set permissions on the PKCS #12 password file"
   file:
-    path: "{{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
+    path: "{{ tls_client_path }}/{{ client_name.stdout }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
     owner: root
     group: root
     mode: 0600
@@ -20,7 +20,7 @@
     label: "{{ client_name.item }}"
 
 - name: "Register the PKCS #12 passwords"
-  command: cat {{ tls_client_path }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password
+  command: cat {{ tls_client_path }}/{{ client_name.stdout }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password
   register: "vpn_client_pkcs12_password_list"
   with_items: "{{ vpn_client_names.results }}"
   loop_control:
@@ -34,11 +34,11 @@
     -in {{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}/client.crt
     -inkey {{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}/client.key
     -name {{ vpn_client_password.client_name.stdout }}
-    -out {{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}.p12
+    -out {{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}/{{ vpn_client_password.client_name.stdout }}.p12
     -certfile {{ tls_client_path }}/ca.crt
     -passout pass:"{{ vpn_client_password.stdout }}"
   args:
-    creates: "{{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}.p12"
+    creates: "{{ tls_client_path }}/{{ vpn_client_password.client_name.stdout }}/{{ vpn_client_password.client_name.stdout }}.p12"
   with_items: "{{ vpn_client_pkcs12_password_list.results }}"
   loop_control:
     loop_var: "vpn_client_password"

--- a/playbooks/roles/openconnect/tasks/docs.yml
+++ b/playbooks/roles/openconnect/tasks/docs.yml
@@ -13,7 +13,7 @@
     creates: "{{ ocserv_gateway_location }}/ca-cert.pem"
 
 - name: "Copy the client PKCS #12 files to the OpenConnect Gateway directory"
-  command: cp {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}.p12 {{ ocserv_gateway_location }}
+  command: cp {{ ocserv_path }}/{{ ocserv_client_password.client_name.stdout }}/{{ ocserv_client_password.client_name.stdout }}.p12 {{ ocserv_gateway_location }}
   args:
     creates: "{{ ocserv_gateway_location }}/{{ ocserv_client_password.client_name.stdout }}.p12"
   with_items: "{{ vpn_client_pkcs12_password_list.results }}"

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -39,7 +39,7 @@
       - "{{ streisand_ipv4_address }}"
 
 - name: Base64 encode the client PKCS12 file(s)
-  command: "openssl base64 -in {{ ocserv_path }}/{{ client_name.stdout }}.p12"
+  command: "openssl base64 -in {{ ocserv_path }}/{{ client_name.stdout }}/{{ client_name.stdout }}.p12"
   register: ocserv_clients_base64
   changed_when: False
   with_items: "{{ vpn_client_names.results }}"


### PR DESCRIPTION
The `certificates` role currently places the generated p12 and p12 password files within the vpn root directory, rather than their respective client directory.

This PR addresses this issue, as well as making the necessary modifications in the `ocserv` docs tasks to work properly (`ocserv` is the only vpn role that currently makes use of p12 files).

Tested on DO droplet with no issues.