### PR TITLE
Enable TCP BBR congestion control

### DIFF
--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -33,6 +33,8 @@ streisand_common_packages:
   # A UUID generator with an explicit random function.
   # Used for generating UUIDs for mobileconfig files
   - uuid
+  # Install Ubuntu LTS Enablement Stacks (HWE or Hardware Enablement) kernel
+  - linux-generic-hwe-16.04
 
 # Services that are running by default but not needed by Streisand
 streisand_unneeded_packages:

--- a/playbooks/roles/sysctl/vars/main.yml
+++ b/playbooks/roles/sysctl/vars/main.yml
@@ -27,3 +27,5 @@ sysctl_values:
   - { key: fs.suid_dumpable, value: 0 }
   - { key: fs.protected_hardlinks, value: 1 }
   - { key: fs.protected_symlinks, value: 1 }
+  - { key: net.core.default_qdisc, value: fq }
+  - { key: net.ipv4.tcp_congestion_control, value: bbr }


### PR DESCRIPTION
From the discussion https://github.com/StreisandEffect/discussions/issues/6
Description: https://research.google.com/pubs/pub45646.html

This PR enables BBR support on Ubuntu 16 LTS, the downside(?) is that it bumps the kernel to 4.13, and the HWE branch suffers a lot of updates, and it could break installs on some providers.

After Streisand is installed, the user needs to reboot so the new kernel is used and BBR is enabled. I've tested on a localhost install on DigitalOcean and everything is running, it would be great to run some benchmarks on the actual gain from using BBR.

