### PR TITLE
Upstreamed SS-libev to 3.1.3

### DIFF
--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -19,7 +19,7 @@ shadowsocks_dependencies:
   - rng-tools
   - libssl-dev
 
-shadowsocks_version: "3.1.2"
+shadowsocks_version: "3.1.3"
 shadowsocks_compilation_directory: "/usr/local/src/shadowsocks-libev-{{ shadowsocks_version }}"
 
 # Configuring the build without documentation means we save close to 900mb of deps


### PR DESCRIPTION
Upstreamed `SS-libev` to `3.1.3`. [Changelog](https://github.com/shadowsocks/shadowsocks-libev/blob/master/debian/changelog) here. 