### PR TITLE
One more place python2 -> python2.7 matters

### DIFF
--- a/streisand
+++ b/streisand
@@ -37,7 +37,7 @@ function check_python() {
   if [[ -n $PYTHON_VERSION && ! $PYTHON_VERSION =~ ^Python\ 2\..* ]]; then
     local INVENTORY_DIR="$SCRIPT_DIR/inventories/"
     for INV_FILE in $INVENTORY_DIR/*; do
-      sed 's/=python$/=python2/' "$INV_FILE" > "$INV_FILE.new"
+      sed 's/=python$/=python2.7/' "$INV_FILE" > "$INV_FILE.new"
       mv "$INV_FILE.new" "$INV_FILE"
       git -C "$INVENTORY_DIR" update-index --assume-unchanged "$INV_FILE" 2>/dev/null || true
     done


### PR DESCRIPTION
This seems to work on bare macOS 10.13, and should resolve #1208.

BTW, I'm inclined to recommend `sudo python -m ensurepip` as the way to get pip on bare macOS. 