### PR TITLE
sslh: send stdout to null instead of journald

### DIFF
--- a/playbooks/roles/sslh/tasks/main.yml
+++ b/playbooks/roles/sslh/tasks/main.yml
@@ -14,3 +14,14 @@
     src: sslh.cfg.j2
     dest: /etc/sslh.cfg
   notify: Restart sslh
+
+- name: Redirect sslh output to /dev/null for privacy
+  lineinfile:
+    path: "/lib/systemd/system/sslh.service"
+    line: "StandardOutput=null"
+    insertafter: "^KillMode=process$"
+    state: present
+
+- name: Reload the systemctl units from disk
+  command: systemctl daemon-reload
+  notify: Restart sslh


### PR DESCRIPTION
This commit updates the `sslh` playbook to edit the upstream `/lib/systemd/system/sslh.service` to set `StandardOutput=null`.

Without this change `sslh` will log client IPs to journald for all of the `:443` connections it multiplexes. We can't turn down the log level without upgrading to `sslh` version `1.18`+, and Ubuntu 16.04 only ships `1.17-2`.

As a short-term workaround this commit will write the output to `/dev/null`. This will make it harder to debug `sslh` related problems but will be a win for privacy.

I'd welcome any improvements for more intelligent filtering. It's a bit of a pain in the butt to pipe things through sed in a systemd world.

Resolves https://github.com/StreisandEffect/streisand/issues/1218