### PR TITLE
OpenVPN: Configurable keepalives, server config comments.

### DIFF
--- a/playbooks/roles/openvpn/templates/etc_openvpn_server.conf.j2
+++ b/playbooks/roles/openvpn/templates/etc_openvpn_server.conf.j2
@@ -1,5 +1,13 @@
+# Use mode `server`- This will route all client connections through a central
+# TUN interface
 server 10.8.0.0 255.255.255.0
+# Push the `dhcp-option` to clients with the DNSMasq IP address bound for
+# OpenVPN and TCP. This will set the primary DNS for the client (with
+# a corresponding `pull` in their config)
 push "dhcp-option DNS {{ dnsmasq_openvpn_tcp_ip }}"
+# Use TCP for the proto
 proto tcp
+# Listen on the OpenVPN TCP port
 port {{ openvpn_port }}
+
 {% include "etc_openvpn_server_common.j2" %}

--- a/playbooks/roles/openvpn/templates/etc_openvpn_server_common.j2
+++ b/playbooks/roles/openvpn/templates/etc_openvpn_server_common.j2
@@ -1,16 +1,38 @@
+# Use dynamic TUN device
 dev tun
+
+# Certificate authority file. PEM encoded root certificate(s)
 ca ca.crt
+
+# Local peer's signed certificate. PEM encoded end-entity cert
 cert server.crt
-key server.key  # This file should be kept secret
+
+# Local peer's private key. PEM encoded private key. Must correspond to `cert`'s
+# public key.
+key server.key
+
+# Diffie hellman parameters. PEM encoded.
 dh {{ dhparams_location }}
+
+# Persist ifconfig-pool data to ipp.txt every 600 seconds (and on startup/shutdown)
 ifconfig-pool-persist ipp.txt
+
+# Push the redirect-gateway option to clients. This will redirect all client
+# traffic over the VPN (per
+# https://openvpn.net/index.php/open-source/documentation/howto.html)
+#
+# TODO(@cpu): I think this is missing a `pull` in the client side...
 push "redirect-gateway def1"
 
 # Fix for the Windows 10 DNS leak described here:
 # https://community.openvpn.net/openvpn/ticket/605
 push block-outside-dns
 
+# Internally route traffic between OpenVPN clients so they can "see" each other.
 client-to-client
+
+# Require peer certificates are signed with x509 client extended key usage bits
+# set (e.g. "TLS Web Client Authentication" EKU)
 remote-cert-tls client
 
 # Allow multiple clients with the same common name to concurrently connect.
@@ -18,15 +40,48 @@ remote-cert-tls client
 # upon connection of a new client having the same common name.
 # duplicate-cn
 
-keepalive 1800 3600
-tls-crypt ta.key # This file is secret
+# Keepalive sets both the client and server ping frequency and timeout interval.
+# It is equivalent to separately setting `ping` and `ping-restart`.
+# On the server the timeout will automatically be adjusted to be 2x as large as
+# the timeout pushed to the client so that the client detects disconnects first.
+keepalive {{ openvpn_keepalive_interval }} {{ openvpn_keepalive_timeout }}
+
+# Encrypt and authenticate all control channel packets with `ta.key`. This is
+# the modern replacement to `tls-auth`. It does not require `key-direction`.
+tls-crypt ta.key
+# Data channel encryption cipher. For OpenVPN clients >2.4 an upgrade to the
+# ncp-cipher understood by both sides.
 cipher {{ openvpn_cipher }}
+# Possible negotiated ciphers for modern OpenVPN clients
 ncp-ciphers {{ openvpn_ncp_ciphers }}
+# HMAC For authenticating data channel packets (Only used for non-AEAD ciphers)
 auth {{ openvpn_auth_digest }}
+# Minimum supported TLS version
 tls-version-min 1.2
+
+# Use LZO compression algorithm. This has better compatibility with OpenVPN
+# clients <2.4.
+# TODO(@cpu): We should consider changing this to `lz4` for better
+# performance/less CPU usage.
 compress lzo
+
+# Avoid paging secrets to disk.
+mlock
+
+# Downgrade UID to `nobody`
 user nobody
+# Downgrade GID to `nobody`
 group nogroup
+
+# Persist keys so they don't need to be re-read when reloading because of
+# keepalive/ping-restart. Since we drop perms to `nobody`/`nogroup` the daemon
+# wouldn't be able to read them from disk again.
 persist-key
+# Similarly, don't close the tun device across restarts because
+# `nobody`/`nogroup` can't open it!
 persist-tun
+
+# Disable all output except for fatal errors
 verb 0
+# Don't log more than 3 identical messages in a row
+mute 3

--- a/playbooks/roles/openvpn/templates/etc_openvpn_server_common.j2
+++ b/playbooks/roles/openvpn/templates/etc_openvpn_server_common.j2
@@ -50,7 +50,8 @@ keepalive {{ openvpn_keepalive_interval }} {{ openvpn_keepalive_timeout }}
 # the modern replacement to `tls-auth`. It does not require `key-direction`.
 tls-crypt ta.key
 # Data channel encryption cipher. For OpenVPN clients >2.4 an upgrade to the
-# ncp-cipher understood by both sides.
+# ncp-cipher understood by both sides should occur. The `cipher` is used only by
+# OpenVPN clients <2.4 that can't handle negotiation.
 cipher {{ openvpn_cipher }}
 # Possible negotiated ciphers for modern OpenVPN clients
 ncp-ciphers {{ openvpn_ncp_ciphers }}

--- a/playbooks/roles/openvpn/templates/etc_openvpn_server_udp.conf.j2
+++ b/playbooks/roles/openvpn/templates/etc_openvpn_server_udp.conf.j2
@@ -1,5 +1,13 @@
+# Use mode `server`- This will route all client connections through a central
+# TUN interface
 server 10.9.0.0 255.255.255.0
+# Push the `dhcp-option` to clients with the DNSMasq IP address bound for
+# OpenVPN and UDP. This will set the primary DNS for the client (with
+# a corresponding `pull` in their config)
 push "dhcp-option DNS {{ dnsmasq_openvpn_udp_ip }}"
+# Use UDP protocol
 proto udp
+# Listen on the UDP OpenVPN port
 port {{ openvpn_port_udp }}
+
 {% include "etc_openvpn_server_common.j2" %}

--- a/playbooks/roles/openvpn/vars/main.yml
+++ b/playbooks/roles/openvpn/vars/main.yml
@@ -13,6 +13,17 @@ openvpn_sslh_profile_filename:       "{{ openvpn_server }}-sslh.ovpn"
 openvpn_stunnel_profile_filename:    "{{ openvpn_server }}-stunnel.ovpn"
 openvpn_combined_profile_filename:   "{{ openvpn_server }}-combined.ovpn"
 
+# Streisand presently uses `keepalive 300 300` which results in the following:
+# On the client:
+#   * Pings are sent every 10s.
+#   * After 60s without pings the connection is restarted
+# On the server:
+#   * Pings are sent every 10s
+#   * After 120s (timeout * 2) without pings the connection is restarted.
+# 10 and 60 are the recommended OpenVPN settings.
+openvpn_keepalive_interval: 10
+openvpn_keepalive_timeout: 60
+
 dnsmasq_openvpn_tcp_ip: "10.8.0.1"
 dnsmasq_openvpn_udp_ip: "10.9.0.1"
 

--- a/playbooks/roles/openvpn/vars/main.yml
+++ b/playbooks/roles/openvpn/vars/main.yml
@@ -13,7 +13,7 @@ openvpn_sslh_profile_filename:       "{{ openvpn_server }}-sslh.ovpn"
 openvpn_stunnel_profile_filename:    "{{ openvpn_server }}-stunnel.ovpn"
 openvpn_combined_profile_filename:   "{{ openvpn_server }}-combined.ovpn"
 
-# Streisand presently uses `keepalive 300 300` which results in the following:
+# Streisand presently uses `keepalive 10 60` which results in the following:
 # On the client:
 #   * Pings are sent every 10s.
 #   * After 60s without pings the connection is restarted


### PR DESCRIPTION
I spent some time in the `openvpn` man page today so here are some small Streisand OpenVPN improvements this commit brings:

* Makes the `keepalive` configurable based on a playbook var
* Lowers the default keepalive interval and timeouts: Previously the OpenVPN connection would have to be broken for about an hour before it would be automatically restarted from the client side (and about two hours on the server side!). This commit applies the OpenVPN recommended values and the  connection should be restarted client-side after ~1m. It should be easier to lower/raise this in the future based on battery life/connectivity trade-off if required.
* Adds `mute 3` to the server config: why not :-)
* Adds `mlock` to the server config: this should be a very small security improvement.
* Adds comments for all of the OpenVPN server configuration. I wanted to understand what each directive did, so I figured it out.