### PR TITLE
Search for "my ip address", since "ip address" sucks now

### DIFF
--- a/global_vars/vars.yml
+++ b/global_vars/vars.yml
@@ -8,3 +8,5 @@ streisand_client_test: no
 streisand_site_vars: "{{ lookup('env','HOME') }}/.streisand/site.yml"
 
 gpg_key_server_address: "x-hkp://pool.sks-keyservers.net"
+
+streisand_my_ip_url: https://encrypted.google.com/search?hl=en&q=my%20ip%20address

--- a/playbooks/roles/l2tp-ipsec/templates/instructions.md.j2
+++ b/playbooks/roles/l2tp-ipsec/templates/instructions.md.j2
@@ -110,7 +110,7 @@ If you're using Windows 10, you can configure the VPN by hand using the followin
 <a name="wincheck"></a>
 #### Checking your connection ####
 
-You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="macOS"></a>
 ### macOS ###
@@ -154,7 +154,7 @@ To activate the VPN:
 * Use the VPN icon in the menu bar, or
 * Open *Network* in *System Preferences*. Click on the Streisand entry in the list of connections. There's a *Connect* button there.
 
-You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="linux"></a>
 ### Linux ###
@@ -183,7 +183,7 @@ L2TP/IPsec connections are not supported out-of-the-box on most Linux distributi
 1. Enter `{{ chap_password.stdout }}` in the *Password* field.
 1. Check the *Save account information* checkbox.
 1. Tap *Connect*.
-1. Once connected, you will see a VPN icon in the notification bar. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Once connected, you will see a VPN icon in the notification bar. You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="ios"></a>
 ### iOS ###
@@ -220,7 +220,7 @@ To activate the VPN:
 
 1. Go to *Settings* -> *General* -> *VPN*.
 1. Slide the *VPN* switch on.
-1. Once connected, you will see a VPN icon in the status bar. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Once connected, you will see a VPN icon in the status bar. You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="chromebook"></a>
 ### Chromebook ###
@@ -234,4 +234,4 @@ To activate the VPN:
 1. Enter `streisand` for the *Username*.
 1. Enter `{{ chap_password.stdout }}` for the *Password*.
 1. Click *Connect*.
-1. Once connected, you will see a VPN icon overlay on the network status icon. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Once connected, you will see a VPN icon overlay on the network status icon. You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.

--- a/playbooks/roles/openconnect/templates/instructions.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions.md.j2
@@ -53,7 +53,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 {% endfor %}
    1. Click *OK*.
    1. Click *OK* to close the connection properties.
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="macos"></a>
 ### macOS ###
@@ -71,7 +71,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 1. Click *Connect*.
 1. A prompt will appear during the initial connection asking you to trust the server's certificate. Click *The information is accurate* and the server will be automatically verified for all future connections.
 1. Enter `{{ ocserv_password.stdout }}` for the *Password* and click *OK*.
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="macos-openconnect-cli"></a>
 #### OpenConnect CLI
@@ -87,7 +87,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 1. Run OpenConnect:
 
   `sudo openconnect --cafile ca.crt --certificate your-client-certificate.p12 --key-password 'your-client-certificate-password' --pfs {{ streisand_ipv4_address }}:{{ ocserv_port }}`
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 
 <a name="linux"></a>
@@ -110,7 +110,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 1. Select the VPN in the left-hand menu, and flip the switch to *ON*. You can also enable/disable the VPN by clicking on the WiFi/Network icon in the menu bar, scrolling to *VPN Connections*, and clicking on its name.
 1. Enter `streisand` for the *Username* and click *Login*.
 1. Enter `{{ ocserv_password.stdout }}` for the *Password*, check *Save passwords*, and click *Login*.
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="android"></a>
 ### Android ###
@@ -139,7 +139,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 1. Tap *Import and Continue* when the Certificate Summary is displayed.
 1. Tap *Connect* on the group selection screen. The correct default has already been chosen.
 1. If this is your first time using AnyConnect, you will need to accept the Connection Request dialog that Android displays.
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 #### Prompted for username? ####
 
@@ -176,4 +176,4 @@ If you're affected, you can use this workaround:
 1. Tap *Details* when the Security Warning is displayed.
 1. Tap *Import* in the top-right corner.
 1. Tap *Connect* on the group selection screen. The correct default has already been chosen.
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.

--- a/playbooks/roles/openvpn/templates/instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions.md.j2
@@ -38,7 +38,7 @@ For security reasons, OpenVPN clients typically have their own unique certificat
 1. Drag and drop the downloaded `{{ openvpn_direct_profile_filename }}` file to this location alongside the README.
 1. Right-click on the OpenVPN icon in your taskbar and choose *Connect*.
 1. You will see a log scroll by as the connection is established, followed by a taskbar notification indicating your assigned IP.
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="macos"></a>
 ### macOS ###
@@ -56,7 +56,7 @@ For security reasons, OpenVPN clients typically have their own unique certificat
 1. Double-click the OpenVPN profile.
 1. You will be asked to choose whether the profile should be available for all users or only the current user. After making your selection, you will be asked to enter your password.
 1. Look for the Tunnelblick icon in your menu bar. Click on it, and choose *Connect*.
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="linux"></a>
 ### Linux ###
@@ -82,7 +82,7 @@ For security reasons, OpenVPN clients typically have their own unique certificat
 1. Execute OpenVPN, and pass it the .ovpn profile as an option.
 
    `sudo openvpn {{ openvpn_direct_profile_filename }}`
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="linux-ubuntu"></a>
 ### Linux (Ubuntu) ###
@@ -130,7 +130,7 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
    * Click *OK*.
 1. Click *Add*
 1. Select the VPN in the left-hand menu, and flip the switch to *ON*. You can also enable/disable the VPN by clicking on the WiFi/Network icon in the menu bar, scrolling to *VPN Connections*, and clicking on its name.
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="android"></a>
 ### Android ###
@@ -149,7 +149,7 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
 1. Tap the save icon (floppy disk) in the lower-right of the screen after the import is complete.
 1. Tap the profile.
 1. Accept the Android VPN connection warning.
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="ios"></a>
 ### iOS ###
@@ -167,7 +167,7 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
 1. OpenVPN on your phone will say that *1 new OpenVPN profile is available for import*.
 1. Tap the green *+* button to import the profile.
 1. Tap the slider to connect to the OpenVPN server.
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="sslh-profiles"></a>
 ### Alternate unified profiles for access via port 443 ###

--- a/playbooks/roles/openvpn/templates/stunnel-instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/stunnel-instructions.md.j2
@@ -47,7 +47,7 @@ Now you are ready to install OpenVPN and configure it to route its traffic throu
 1. Drag and drop the downloaded `{{ openvpn_stunnel_profile_filename }}` file to this location alongside the README.
 1. Right-click on the OpenVPN icon in your taskbar and choose *Connect*.
 1. You will see a log scroll by as the connection is established, followed by a taskbar notification indicating your assigned IP.
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="macos"></a>
 ### macOS ###
@@ -81,7 +81,7 @@ Now you are ready to install OpenVPN and configure it to route its traffic throu
 1. Double-click the OpenVPN profile.
 1. You will be asked to choose whether the profile should be available for all users or only the current user. After making your selection, you will be asked to enter your password.
 1. Look for the Tunnelblick icon in your menu bar. Click on it, and choose *Connect*.
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="linux"></a>
 ### Linux ###
@@ -123,7 +123,7 @@ Now you are ready to install OpenVPN and configure it to route its traffic throu
 1. Execute OpenVPN, and pass it the .ovpn profile as an option:
 
    `sudo openvpn {{ openvpn_stunnel_profile_filename }}`
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 The OpenVPN plugin for NetworkManager appears to become very confused as to how it should route traffic when you connect to an OpenVPN server through a wrapped stunnel connection. Manually adding route information does not seem to help. Therefore, unlike in the [non-stunnel instructions](/openvpn), the steps above are the recommended connection method for Ubuntu as well.
 
@@ -158,7 +158,7 @@ Now you are ready to install OpenVPN for Android and configure it to route its t
 1. Tap the save icon (floppy disk) in the lower-right of the screen after the import is complete.
 1. Tap the profile.
 1. Accept the Android VPN connection warning.
-1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. Success! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="ios"></a>
 iOS

--- a/playbooks/roles/shadowsocks/templates/instructions.md.j2
+++ b/playbooks/roles/shadowsocks/templates/instructions.md.j2
@@ -25,7 +25,7 @@ Shadowsocks
    1. The *SOCKS 5 Proxy Port* should be `{{ shadowsocks_local_port }}` and the *Encryption Method* should be `{{ shadowsocks_encryption_method }}`.
    1. Click *Save*.
 1. Click on the Shadowsocks menu tray icon and select *Enable*.
-1. That's it! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. That's it! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="macos"></a>
 ### macOS ###
@@ -43,7 +43,7 @@ Shadowsocks
    1. Click *OK*.
 1. Click on the Shadowsocks icon in the menu bar again, and choose *Global Mode*.
 1. You can use the Shadowsocks icon to enable/disable the VPN. The color of the icon will change based on whether or not it is active.
-1. That's it! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. That's it! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="linux"></a>
 ### Linux ###
@@ -87,7 +87,7 @@ This should return a 301 Found response **not** a connection refused error.
 1. Select *Remote DNS*. This configures Firefox to send all DNS requests through the SOCKS proxy. This will protect you against DNS poisoning and ensure that false DNS entries cannot be used to censor your access.
 1. Click *OK*.
 1. Click *OK* again to close the Firefox preferences window.
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 
 <a name="android"></a>
@@ -101,7 +101,7 @@ This should return a 301 Found response **not** a connection refused error.
    ![Shadowsocks QR code](/shadowsocks/shadowsocks-qr-code.png)
 1. Tap the round paper plane icon along the bottom-left bar.
 1. Accept the Android VPN connection warning.
-1. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="ios"></a>
 ### iOS ###
@@ -113,7 +113,7 @@ This should return a 301 Found response **not** a connection refused error.
    ![Shadowsocks QR code](/shadowsocks/shadowsocks-qr-code.png)
 1. Toggle the connection switch located to the right of the *Not Connected* text on the *Home* tab.
    * If this is your first time running Shadowrocket, iOS will ask you to verify that the application should have permission to add VPN configurations. Tap *Allow* and follow the instructions.
-1. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="simple-obfs"></a>
 ### simple-obfs for unreliable/hostile networks ###

--- a/playbooks/roles/ssh-forward/templates/instructions.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions.md.j2
@@ -53,7 +53,7 @@ You are now connected and have a SOCKS proxy up and running that is ready to for
 1. Select *Remote DNS*. This configures Firefox to send all DNS requests through the SOCKS proxy. This will protect you against DNS poisoning and ensure that false DNS entries cannot be used to censor your access.
 1. Click *OK*.
 1. Click *OK* again to close the Firefox preferences window.
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="linux-and-macos"></a>
 ### Linux and macOS ###
@@ -119,7 +119,7 @@ Sshuttle is a simple VPN tunnelling solution that operates over the SSH transpor
    `{{ ssh_server_fingerprints.results[0].stdout }}`
 
    `{{ ssh_server_fingerprints.results[1].stdout }}`
-1. All of your traffic, including DNS, is now being transparently forwarded through an encrypted SSH connection. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. All of your traffic, including DNS, is now being transparently forwarded through an encrypted SSH connection. You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 {% endif %}
 

--- a/playbooks/roles/wireguard/templates/instructions.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions.md.j2
@@ -31,7 +31,7 @@ WireGuard is currently only available for Linux, but [cross-platform](https://ww
 
    'sudo systemctl enable wg-quick@wg0-client.service'
 
-1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 1. To stop routing your traffic through WireGuard, simply bring the interface back down:
 
    `sudo wg-quick down wg0-client`


### PR DESCRIPTION
I think Google used to give you your connection's current address when you searched for `ip address`. That seems to be sorta broken now. Searching for `my ip address` gives you an info box with the address right at the top.

I am totally up for a better place to put the variable.