### PR TITLE
CI: Explicitly connect LXD snap plugs.

### DIFF
--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -62,6 +62,12 @@
     - name: "Install LXD snap"
       command: "snap install lxd"
 
+    - name: "Connect LXD plug to slots"
+      command: "{{ item }}"
+      with_items:
+        - "snap connect lxd:lxd-support"
+        - "snap connect lxd:network"
+
     - name: "Start lxd"
       command: "snap start lxd"
 


### PR DESCRIPTION
This commit adds explicit `snap connect` invocations for `lxd:lxd-support` and `lxd:lxd-network`. Without these the LXD snap services fail to start and CI stalls waiting for the LXD socket to become available.

I admit to not understanding _why_ these commands are required, or exactly what "snap plugs" are. Computers are a hot mess :-(

I discovered this workaround after finding https://bugs.launchpad.net/snapd/+bug/1657252 which leads me to believe this is a bug in the upstream `snapd` package.

As one definitive data point, changing out the LXD snap from the recently released `3.0.0` to the `2.0/stable` release channel did not fix the problem observed in CI.

Resolves https://github.com/StreisandEffect/streisand/issues/1252