### PR TITLE
Allow to use the same certificates for OpenVPN by default

### DIFF
--- a/playbooks/roles/openvpn/templates/etc_openvpn_server_common.j2
+++ b/playbooks/roles/openvpn/templates/etc_openvpn_server_common.j2
@@ -16,7 +16,7 @@ remote-cert-tls client
 # Allow multiple clients with the same common name to concurrently connect.
 # In the absence of this option, OpenVPN will disconnect a client instance
 # upon connection of a new client having the same common name.
-# duplicate-cn
+duplicate-cn
 
 keepalive 1800 3600
 tls-crypt ta.key # This file is secret


### PR DESCRIPTION
It's disabled by default although it is written that it is available
> For security reasons, OpenVPN clients typically have their own unique certificate and private key. The server you will be connecting to **has been configured to allow clients to share the same certificate and private key**, but you may still wish to give your phone and laptop different keys, for example.