### PR TITLE
Common: use explicit --random-source for shuf

### DIFF
--- a/playbooks/roles/certificates/tasks/ca-server.yml
+++ b/playbooks/roles/certificates/tasks/ca-server.yml
@@ -23,7 +23,7 @@
     creates: "{{ tls_ca }}.crt"
 
 - name: Generate a random server common name
-  shell: "{{ streisand_word_gen.long_identifier }} > {{ tls_server_common_name_file }}"
+  shell: "{{ streisand_word_gen.long_identifier | trim }} > {{ tls_server_common_name_file }}"
   args:
     creates: "{{ tls_server_common_name_file }}"
 

--- a/playbooks/roles/certificates/tasks/pkcs.yml
+++ b/playbooks/roles/certificates/tasks/pkcs.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Generate a random password that will be used during the PKCS #12 conversion"
-  shell: "{{ streisand_word_gen.weak_password }} > {{ tls_client_path }}/{{ client_name.stdout }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
+  shell: "{{ streisand_word_gen.weak_password | trim }} > {{ tls_client_path }}/{{ client_name.stdout }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
   args:
     creates: "{{ tls_client_path }}/{{ client_name.stdout }}/{{ vpn_name }}-{{ client_name.stdout }}-pkcs12-password"
   with_items: "{{ vpn_client_names.results }}"

--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -68,12 +68,14 @@ streisand_languages:
     language_name: "Français"
     tor_locale: "fr"
 
+streisand_shuf: "shuf --random-source=/dev/urandom"
+
 streisand_word_gen:
-  gateway:
-    shuf -n 6 /usr/share/dict/english.txt |
+  gateway: >
+    {{ streisand_shuf }} -n 6 /usr/share/dict/english.txt |
     paste -s -d '.' -
-  identifier:
-    shuf -n 2 /usr/share/dict/english.txt |
+  identifier: >
+    {{ streisand_shuf }} -n 2 /usr/share/dict/english.txt |
     paste -s -d '-' -
   # Tor only likes [A-Za-z0-9] for nicknames.
   #
@@ -82,19 +84,19 @@ streisand_word_gen:
   # Tor nicknames should be 19 characters or fewer; cut ours off at 18.
   #
   # Caps script from https://www.unix.com/302904939-post2.html
-  tor_nickname:
-    shuf -n 2 /usr/share/dict/english.txt |
+  tor_nickname: >
+    {{ streisand_shuf }} -n 2 /usr/share/dict/english.txt |
     awk '{OFS=""; for(j=1;j<=NF;j++){ $j=toupper(substr($j,1,1)) substr($j,2) }}1' |
     tr -d '\n' |
     cut -b 1-18
-  long_identifier:
-    shuf -n 3 /usr/share/dict/english.txt |
+  long_identifier: >
+    {{ streisand_shuf }} -n 3 /usr/share/dict/english.txt |
     paste -s -d '-' -
-  weak_password:
-    shuf -n 3 /usr/share/dict/english.txt |
+  weak_password: >
+    {{ streisand_shuf }} -n 3 /usr/share/dict/english.txt |
     paste -s -d '.' -
-  psk:
-    shuf -n 5 /usr/share/dict/english.txt |
+  psk: >
+    {{ streisand_shuf }} -n 5 /usr/share/dict/english.txt |
     paste -s -d '.' -
 
 # In online documentation, we recommand a URL for people to check

--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -46,7 +46,7 @@
     mode: 0644
 
 - name: Generate a random IPsec pre-shared key
-  shell: "{{ streisand_word_gen.psk }}  > {{ ipsec_preshared_key_file }}"
+  shell: "{{ streisand_word_gen.psk | trim }}  > {{ ipsec_preshared_key_file }}"
   args:
     creates: "{{ ipsec_preshared_key_file }}"
 
@@ -100,7 +100,7 @@
     mode: 0644
 
 - name: Generate a random CHAP password
-  shell: "{{ streisand_word_gen.weak_password }} > {{ chap_password_file }}"
+  shell: "{{ streisand_word_gen.weak_password | trim }} > {{ chap_password_file }}"
   args:
     creates: "{{ chap_password_file }}"
 

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -70,7 +70,7 @@
     label: "{{ client_content[0].item }}"
 
 - name: Generate a random ocserv password
-  shell: "{{ streisand_word_gen.psk }} > {{ ocserv_password_file }}"
+  shell: "{{ streisand_word_gen.psk | trim }} > {{ ocserv_password_file }}"
   args:
     creates: "{{ ocserv_password_file }}"
 

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -7,7 +7,7 @@
 - include_vars: ../../lets-encrypt/vars/main.yml
 
 - name: Generate a random Gateway password
-  shell: "{{ streisand_word_gen.gateway }} > {{ streisand_gateway_password_file }}"
+  shell: "{{ streisand_word_gen.gateway | trim }} > {{ streisand_gateway_password_file }}"
   args:
     creates: "{{ streisand_gateway_password_file }}"
 

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -27,7 +27,7 @@
 - import_tasks: firewall.yml
 
 - name: Generate a random Nickname for the bridge
-  shell: "{{ streisand_word_gen.tor_nickname }} > {{ tor_bridge_nickname_file }}"
+  shell: "{{ streisand_word_gen.tor_nickname | trim }} > {{ tor_bridge_nickname_file }}"
   args:
     creates: "{{ tor_bridge_nickname_file }}"
 


### PR DESCRIPTION
Resolves https://github.com/StreisandEffect/streisand/issues/1259

Note: I changed the `shuf` calls to use a variable, which in turn caused quoting issues until I switched to the `>` "Folded block scalar" YAML syntax. Doing _that_ caused an extra `\n` to get tacked on the end and this caused places we used the var in `shell` pipeline expression to break unless there was a `| trim`. Phew! I'm certainly open to cleaner alternatives/suggestions but I want to land a fix to 1259 ASAP.