### PR TITLE
Always customize installation

### DIFF
--- a/playbooks/customize.yml
+++ b/playbooks/customize.yml
@@ -9,7 +9,7 @@
       default: "~/.ssh/id_rsa"
       private: no
     - name: vpn_clients
-      prompt: "How many VPN client profiles should be generated per-service? Press enter for default "
+      prompt: "How many VPN client profiles should be generated per-service (min: 1 max: 20)? Press enter for default "
       default: 5
       private: no
     - name: streisand_openconnect_enabled

--- a/streisand
+++ b/streisand
@@ -61,18 +61,18 @@ function validate() {
 function customize() {
   read -r -p "
 Do you wish to customize which services Streisand will install?
-By default Streisand will use the settings configured in $SITE_VARS
+By saying 'no' Streisand will use the settings configured in $SITE_VARS
 
-Please enter the word 'yes' to customize or hit enter to continue: " confirm
+Press enter to customize your installation: " confirm
   case "$confirm" in
-    yes) echo; echo "Confirmed. Customizing Streisand services.";
+    no) echo; echo "Installing Streisand services specified in $SITE_VARS";;
+     *) echo; echo "Confirmed. Customizing Streisand services.";
          # NOTE(@cpu): We don't pass the other `--extra-vars` here because the
          # customize `vars_prompt` will only happen if the vars aren't already
          # set. If you pass the site/defaults in no prompting will happen.
          echo; echo; ansible-playbook \
            --extra-vars="@$GLOBAL_VARS" \
            playbooks/customize.yml;;
-    *) echo; echo "Installing Streisand services specified in $SITE_VARS";;
   esac
 }
 


### PR DESCRIPTION
Make customizing the install a default action, answering `no` will read from the defined site-vars.

Resolves #1225