### PR TITLE
Remove SSH service monitor from monitrc

### DIFF
--- a/playbooks/roles/monit/templates/monitrc.j2
+++ b/playbooks/roles/monit/templates/monitrc.j2
@@ -11,14 +11,6 @@ set httpd port 2812 and
     # and requiring basic auth (through nginx) should be sufficient to protect this interface.
     allow 0.0.0.0/0.0.0.0 # allow any ip to connect to monit.
 
-# OpenSSH
-check process sshd with pidfile /var/run/sshd.pid
-   start program  "/usr/sbin/service ssh start"
-   stop program  "/usr/sbin/service ssh stop"
-   if failed port {{ ssh_port }} protocol ssh then restart
-   # if 5 restarts within 5 cycles then timeout
-
-
 # dnsmasq
 check process dnsmasq with pidfile /var/run/dnsmasq/dnsmasq.pid
   start program = "/usr/sbin/service dnsmasq start" with timeout 60 seconds


### PR DESCRIPTION
The bundled ssh.service systemd unit is already set to restart on failure allowing us to safely remove monit's ssh monitor.

Bundled ssh.service:

```
[Unit]
Description=OpenBSD Secure Shell server
After=network.target auditd.service
ConditionPathExists=!/etc/ssh/sshd_not_to_be_run

[Service]
EnvironmentFile=-/etc/default/ssh
ExecStart=/usr/sbin/sshd -D $SSHD_OPTS
ExecReload=/bin/kill -HUP $MAINPID
KillMode=process
Restart=on-failure
RestartPreventExitStatus=255
Type=notify

[Install]
WantedBy=multi-user.target
Alias=sshd.service
```