### PR TITLE
Remove sslh monitor from monit

### DIFF
--- a/playbooks/roles/monit/templates/monitrc.j2
+++ b/playbooks/roles/monit/templates/monitrc.j2
@@ -53,14 +53,6 @@ check process tinyproxy with pidfile /var/run/tinyproxy/tinyproxy.pid
 
 {% endif %}
 
-# sslh
-check process sslh with pidfile /var/run/sslh/sslh.pid
-   start program  "/usr/sbin/service sslh start"
-   stop program  "/usr/sbin/service sslh stop"
-   if failed host {{ ansible_default_ipv4.address }} port 443 type tcp then restart
-   # if 5 restarts within 5 cycles then timeout
-
-
 # Configuration Credits
 # --
 # dnsmasq

--- a/playbooks/roles/sslh/handlers/main.yml
+++ b/playbooks/roles/sslh/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart sslh
-  service:
-    name: sslh
+  systemd:
+    name: sslh.service
     state: restarted

--- a/playbooks/roles/sslh/tasks/main.yml
+++ b/playbooks/roles/sslh/tasks/main.yml
@@ -15,13 +15,20 @@
     dest: /etc/sslh.cfg
   notify: Restart sslh
 
-- name: Redirect sslh output to /dev/null for privacy
-  lineinfile:
-    path: "/lib/systemd/system/sslh.service"
-    line: "StandardOutput=null"
-    insertafter: "^KillMode=process$"
-    state: present
+- name: Create the sslh systemd drop-in configuration directory
+  file:
+    path: "{{ sslh_systemd_service_path }}"
+    state: directory
 
-- name: Reload the systemctl units from disk
-  command: systemctl daemon-reload
-  notify: Restart sslh
+- name: Generate the sslh systemd drop-in service file
+  template:
+    src: sslh.service.j2
+    dest: "{{ sslh_systemd_service_path }}/10-restart-failure.conf"
+    mode: 0644
+
+- name: Enable the sslh service
+  systemd:
+    daemon_reload: yes
+    name: sslh.service
+    enabled: yes
+    state: restarted

--- a/playbooks/roles/sslh/templates/sslh.cfg.j2
+++ b/playbooks/roles/sslh/templates/sslh.cfg.j2
@@ -2,7 +2,7 @@ verbose: false;
 foreground: true;
 timeout: 5;
 user: "sslh";
-pidfile: "/var/run/sslh/sslh.pid";
+pidfile: "{{ sslh_pid_file }}";
 
 listen:
 (

--- a/playbooks/roles/sslh/templates/sslh.service.j2
+++ b/playbooks/roles/sslh/templates/sslh.service.j2
@@ -1,0 +1,6 @@
+[Service]
+PrivateTmp=true
+StandardOutput=null
+RestartSec=5s
+Restart=on-failure
+PIDFile={{ sslh_pid_file }}

--- a/playbooks/roles/sslh/vars/main.yml
+++ b/playbooks/roles/sslh/vars/main.yml
@@ -1,0 +1,3 @@
+---
+sslh_pid_file: "/var/run/sslh/sslh.pid"
+sslh_systemd_service_path: "/etc/systemd/system/sslh.service.d"


### PR DESCRIPTION
- create an sslh systemd drop-in file
- move `StandardOutput=null` to drop-in
- use a variable for sslh pid file
- remove sslh monitor from monitrc