### PR TITLE
Add `-v` flag to user instructions for SSH port forwarding

### DIFF
--- a/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
@@ -114,7 +114,7 @@ Sshuttle est une simple solution de tunneling VPN qui fonctionne sur le transpor
 
 1. `SSH`ez dans le serveur et transférer un port SOCKS dynamique:
 
-   `ssh -D {{ ssh_default_socks_port }} forward@{{ streisand_server_name }}`
+   `ssh -vND {{ ssh_default_socks_port }} forward@{{ streisand_server_name }}`
 1. Vérifiez que les empreintes numériques correspondent à l'un des éléments ci-dessous:
 
    `{{ ssh_server_fingerprints.results[0].stdout }}`

--- a/playbooks/roles/ssh-forward/templates/instructions.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions.md.j2
@@ -78,7 +78,7 @@ You are now connected and have a SOCKS proxy up and running that is ready to for
 
 1. SSH into the server and forward a dynamic SOCKS port:
 
-   `ssh -ND {{ ssh_default_socks_port }} forward@{{ streisand_server_name }}`
+   `ssh -vND {{ ssh_default_socks_port }} forward@{{ streisand_server_name }}`
 1. Verify that the fingerprint matches one of these:
 
    `{{ ssh_server_fingerprints.results[0].stdout }}`


### PR DESCRIPTION
As per [issue 1284](https://github.com/StreisandEffect/streisand/issues/1284), a flag for verbose output is added to the SSH port-forwarding command which a user is instructed to run. This allows for verifying fingerprints without branching instructions for different users.

In addition, the French instructions lacked the `-N` flag for the same command, which has been added.