### PR TITLE
Let's Encrypt: tweak prompt wording

### DIFF
--- a/playbooks/lets-encrypt.yml
+++ b/playbooks/lets-encrypt.yml
@@ -14,32 +14,34 @@
   vars_prompt:
     - name: "streisand_domain_var"
       prompt: |
-        Which domain do you want to use to host Streisand server?
+        Do you have a fully qualified domain pointed at your Streisand server?
 
         This is an optional question. If you have a domain that points to your
-        Streisand server, the installation scripts can request Let's Encrypt
-        HTTPS certificates for you automatically.  If you do not provide one or
-        the request fails, self-signed certificates will be used instead.
+        Streisand server, the installation scripts can request a Let's Encrypt
+        HTTPS certificate for you automatically.  If you do not provide one or
+        the request fails, a self-signed certificate will be used instead.
 
-        If you have just created a new cloud server in previous steps, it is
-        good time to point your domain to your server's public address, as DNS
-        changes take time to propagate.
+        If you have just created a new cloud server in previous steps now is a
+        good time to point your fully qualified domain to your server's public
+        address. Make sure the fully qualified domain resolves to the correct IP
+        address before proceeding.
 
-        Please type your domain below. Press enter to skip.
+        Please type your fully qualified domain below. Press enter to skip.
       private: no
 
     - name: "streisand_admin_email_var"
       prompt: |
-        Which email address do you want to use as contact for the Streisand
+        Which email address do you want to use as a contact for the Streisand
         server's Let's Encrypt certificate?
 
-        This is an optional question. If you supply an email address, Let's
-        Encrypt will send you important (but very infrequent) notifications
-        about using the certificate. This mail includes any upcoming certificate
+        This is an optional question. If you supply an email address Let's
+        Encrypt will send you important (but infrequent) notifications about
+        your certificate. These messages include any upcoming certificate
         expirations, and important changes to the Let's Encrypt service.
-        The email will not be used for anything else.
+        The email provided will not be used for anything else or shared with the
+        Streisand developers.
 
-        Please type your email below. Press enter to skip.
+        Please type your contact email below. Press enter to skip.
       private: no
 
   pre_tasks:


### PR DESCRIPTION
Primarily this change emphasizes that you need to enter a fully qualified domain name.