### PR TITLE
GPG: explicitly wait for dirmngr and gpg-agent sockets.

### DIFF
--- a/playbooks/roles/download-and-verify/tasks/main.yml
+++ b/playbooks/roles/download-and-verify/tasks/main.yml
@@ -23,6 +23,15 @@
 
 - name: "Verify the {{ project_name }} download signatures with the Streisand GPG keyring"
   command: "gpgv2 --keyring {{ streisand_gpg_keyring }} {{ project_download_location }}/{{ item.sig }} {{ project_download_location }}/{{ item.file }}"
+  environment:
+    # We need to explicitly override the configured LANG, LC_MESSAGES and LC_ALL
+    # env vars to ensure that we can match on English output even on systems
+    # that have a non-english locale configured. It's _probably_ enough to
+    # override just LANG but it sounds like there are some cases where LC_ALL
+    # takes precedence and setting env vars is cheap!
+    LANG: "en_US.UTF-8"
+    LC_MESSAGES: "en_US.UTF-8"
+    LC_ALL: "en_US.UTF-8"
   register: gpg_verification_results
   with_items: "{{ project_download_files }}"
 

--- a/playbooks/roles/gpg/tasks/main.yml
+++ b/playbooks/roles/gpg/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: "Create the GPG directory"
   file:
-    path: "/root/.gnupg/"
+    path: "{{ root_gpg_dir }}"
     state: directory
     owner: root
     group: root
@@ -34,10 +34,26 @@
 - name: "Write the Streisand GPG dirnmgr config"
   template:
     src: "dirmngr.conf.j2"
-    dest: "/root/.gnupg/dirmngr.conf"
+    dest: "{{ root_gpg_dir }}/dirmngr.conf"
     owner: root
     group: root
     mode: 0750
+
+- name: "Start the GPG agent"
+  command: "gpg-agent --homedir {{ root_gpg_dir }} --use-standard-socket --daemon"
+
+- name: "Start the dirmngr"
+  command: "dirmngr --homedir {{ root_gpg_dir }} --daemon"
+
+- name: "Wait for the GPG agent and dirmngr control sockets"
+  wait_for:
+    path: "{{ root_gpg_dir }}/{{ item }}"
+    state: present
+    sleep: 5
+    timeout: 60
+  with_items:
+    - "S.dirmngr"
+    - "S.gpg-agent"
 
 - name: "Create the Streisand GPG keyring"
   command: "gpg2 {{ streisand_default_gpg_flags }} --fingerprint"
@@ -49,16 +65,6 @@
     src: "{{ item }}"
     dest: "{{ streisand_gpg_dir }}/keys/{{ item }}"
   with_items: "{{ streisand_bootstrap_gpg_keys }}"
-
-- name: "Wait for the GPG agent and dirmngr control sockets"
-  wait_for:
-    path: "{{ streisand_gpg_dir }}/{{ item }}"
-    state: present
-    sleep: 5
-    timeout: 60
-  with_items:
-    "S.dirmngr"
-    "S.gpg-agent"
 
 - name: "Import the bootstrap GPG public keys to the Streisand GPG keyring"
   command: "gpg2 {{ streisand_default_gpg_flags }} --import {{ streisand_gpg_dir }}/keys/{{ item }}"

--- a/playbooks/roles/gpg/tasks/main.yml
+++ b/playbooks/roles/gpg/tasks/main.yml
@@ -50,6 +50,16 @@
     dest: "{{ streisand_gpg_dir }}/keys/{{ item }}"
   with_items: "{{ streisand_bootstrap_gpg_keys }}"
 
+- name: "Wait for the GPG agent and dirmngr control sockets"
+  wait_for:
+    path: "{{ streisand_gpg_dir }}/{{ item }}"
+    state: present
+    sleep: 5
+    timeout: 60
+  with_items:
+    "S.dirmngr"
+    "S.gpg-agent"
+
 - name: "Import the bootstrap GPG public keys to the Streisand GPG keyring"
   command: "gpg2 {{ streisand_default_gpg_flags }} --import {{ streisand_gpg_dir }}/keys/{{ item }}"
   with_items: "{{ streisand_bootstrap_gpg_keys }}"

--- a/playbooks/roles/gpg/vars/main.yml
+++ b/playbooks/roles/gpg/vars/main.yml
@@ -1,7 +1,9 @@
 ---
 
+root_gpg_dir: "/root/.gnupg"
+
 # Keep Streisand's GPG cruft out of the way
-streisand_gpg_dir: "/root/.gnupg/streisand"
+streisand_gpg_dir: "{{ root_gpg_dir }}/streisand"
 
 # Where is the Streisand specific GPG keyring kept?
 streisand_gpg_keyring: "{{ streisand_gpg_dir }}/pubring.gpg"


### PR DESCRIPTION
#### GPG: explicitly wait for dirmngr and gpg-agent sockets.

A user provisioning Streisand on Azure [reports a persistent failure](https://github.com/StreisandEffect/streisand/issues/1308#issue-318237314) during the Streisand GPG keyring import task with the following error msg:
> "gpg: can't connect to the agent: IPC connect call failed"

This is (likely?) caused by the gpg-agent not having started by the time we import the keys. I can't reproduce the bug myself so this may be a red herring.

This PR changes the gpg playbook to explicitly start both the gpg-agent and the dirnmgr instead of letting the first gpg operation do so. This PR also adds an explicit `wait_for` task for both the dirnmgr and gpg agent control sockets to make sure we don't proceed until both daemons are available.

#### GPG: Use explicit English locale for gpgv2.

The download-and-verify playbook invokes `gpg2` to check GPG signatures. In addition to checking the return code for success we regex match the key ID that was used to successfully validate the signature. The successful match of this regex depends on the `gpgv2` output being in English. If a user has override their `LANG` to something else then the regex will fail to match! See: https://github.com/StreisandEffect/streisand/issues/1199#issuecomment-378677563 for more.

This PR addresses this case by explicitly forcing the locale to "en_US.UTF-8" when invoking `gpgv2`, ignoring the system locale configuration.

Its likely bugs like this exist other places in Streisand but at least this one is fixed!

Updates https://github.com/StreisandEffect/streisand/issues/1308