### PR TITLE
Center the Streisand logo in the Readme

### DIFF
--- a/README-chs.md
+++ b/README-chs.md
@@ -1,4 +1,6 @@
-![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect")
+<p align="center">
+  <img src="https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg" alt="Automate the effect"/> 
+</p>
 
 - - -
 [English](README.md), [Français](README-fr.md), [简体中文](README-chs.md), [Русский](README-ru.md) | [Mirror](https://gitlab.com/alimakki/streisand)

--- a/README-fr.md
+++ b/README-fr.md
@@ -1,4 +1,6 @@
-![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect")
+<p align="center">
+  <img src="https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg" alt="Automate the effect"/> 
+</p>
 
 - - -
 [English](README.md), [Français](README-fr.md), [简体中文](README-chs.md), [Русский](README-ru.md) | [Miroir](https://gitlab.com/alimakki/streisand)

--- a/README-ru.md
+++ b/README-ru.md
@@ -1,4 +1,6 @@
-![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Автоматизируйте эффект Стрейзанд!")
+<p align="center">
+  <img src="https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg" alt="Automate the effect"/> 
+</p>
 
 - - -
 [English](README.md), [Français](README-fr.md), [简体中文](README-chs.md), [Русский](README-ru.md) | [Зеркало](https://gitlab.com/alimakki/streisand)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect")
+<p align="center">
+  <img src="https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg" alt="Automate the effect"/> 
+</p>
 
 - - -
 [English](README.md), [Français](README-fr.md), [简体中文](README-chs.md), [Русский](README-ru.md) | [Mirror](https://gitlab.com/alimakki/streisand)


### PR DESCRIPTION
Okay, I know this is a really weird PR. But for a while now It has bugged me that the Streisand logo in the Readme was not centered. It is aligned to the left. Feel free to reject this PR but GitHub supports HTML in MD files so I just centered the image. I also retained the alt text if that is a requirement

Before:
![image](https://user-images.githubusercontent.com/10386884/39527032-0c106cd6-4de6-11e8-9e8f-f923dc6fef2c.png)

After:
![image](https://user-images.githubusercontent.com/10386884/39527055-1b08fa0a-4de6-11e8-9411-7e6c0c4b8689.png)

Additionally, if you want to see a live render of it visit https://github.com/Frichetten/streisand/tree/center_readme_logo which should be my branch with this change.
