### PR TITLE
Bump Ansible CI to v2.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - sudo apt-get install python-pip python-dev ca-certificates shellcheck -qq
 
 install:
-  - pip install ansible==2.4.0.0
+  - pip install ansible==2.5.2
   - pip install urllib3 yamllint
   - ansible --version
 

--- a/playbooks/roles/validation/tasks/ssh.yml
+++ b/playbooks/roles/validation/tasks/ssh.yml
@@ -19,11 +19,6 @@
       when:
         - streisand_new_server_provisioning
         - not streisand_ssh_key_status.stat.exists
-      #- name: "Register the Streisand SSH public key"
-      #command: "cat {{ streisand_ssh_private_key }}.pub"
-      #register: streisand_ssh_key
-      #changed_when: False
-
   rescue:
     - fail:
         msg: "Ensure you specified an existing SSH private key file. Ensure a corresponding SSH public key file exists if you are setting up a new server.\n Try using `ssh-keygen -f {{ streisand_ssh_private_key }} to generate your key if it does not exist\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 # Quick fix: Ansible 2.5.1 is broken; use 2.5.0 until at least version
 # 2.5.2 is released.
 #
-ansible[azure]==2.5.0
+ansible[azure]==2.5.2
 
 # Multiple packages depend on SecretStorage, and versions >= 3 require
 # Python 3. Until we're ready for Python 3, specify the earlier rev.

--- a/tests/run.yml
+++ b/tests/run.yml
@@ -26,7 +26,7 @@
         - name: Check Streisand configuration is valid
           include_role:
             name: validation
-      delegate_to: 127.0.0.1
+      delegate_to: localhost
 
     - name: Ensure openssh is installed
       apt:

--- a/util/ansible_check.sh
+++ b/util/ansible_check.sh
@@ -6,7 +6,7 @@ set -e
 # check_ansible checks that Ansible is installed on the local system
 # and that it is a supported version.
 function check_ansible() {
-  local REQUIRED_ANSIBLE_VERSION="2.4.0"
+  local REQUIRED_ANSIBLE_VERSION="2.5.2"
 
   if ! command -v ansible > /dev/null 2>&1; then
     echo "


### PR DESCRIPTION
Raise the minimum version of Ansible to v2.5.2, will likely allow #1229 to be merged afterwards.

Resolves #1276