### PR TITLE
Change "Localhost" to "localhost"

### DIFF
--- a/streisand
+++ b/streisand
@@ -187,7 +187,7 @@ read -r -p "Which provider are you using?
   4. Google
   5. Linode
   6. Rackspace
-  7. Localhost (Advanced)
+  7. localhost (Advanced)
   8. Existing Server (Advanced)
 : " reply
 


### PR DESCRIPTION
Use "localhost" instead. I got confused and thought there was a cloud provider called "Localhost" so I selected option 8 (Existing Server) when I should have selected option 7.  Everyone is used to seeing localhost when referring to localhost. Localhost with a capital L is a proper name.