### PR TITLE
ensure gpgagent is dead before trying to start it Fixes #1333

### DIFF
--- a/playbooks/roles/gpg/tasks/main.yml
+++ b/playbooks/roles/gpg/tasks/main.yml
@@ -39,6 +39,9 @@
     group: root
     mode: 0750
 
+- name: "Ensure GPG agent is dead"
+  command: "gpgconf --kil gpg-agent"
+
 - name: "Start the GPG agent"
   command: "gpg-agent --homedir {{ root_gpg_dir }} --use-standard-socket --daemon"
 

--- a/playbooks/roles/gpg/tasks/main.yml
+++ b/playbooks/roles/gpg/tasks/main.yml
@@ -39,7 +39,7 @@
     group: root
     mode: 0750
 
-- name: "Start the GPG agent if it's not already started"
+- name: "Ensure gpg-agent is started and running the latest config"
   command: "pgrep gpg-agent || gpg-agent --homedir {{ root_gpg_dir }} --use-standard-socket --daemon && gpgconf --reload gpg-agent"
 
 - name: "Start the dirmngr"

--- a/playbooks/roles/gpg/tasks/main.yml
+++ b/playbooks/roles/gpg/tasks/main.yml
@@ -39,8 +39,18 @@
     group: root
     mode: 0750
 
-- name: "Ensure gpg-agent is started and running the latest config"
-  command: "pgrep gpg-agent || gpg-agent --homedir {{ root_gpg_dir }} --use-standard-socket --daemon && gpgconf --reload gpg-agent"
+- name: check if gpg-agent is running
+  command: gpg-agent
+  register: gpg_result
+  ignore_errors: True
+
+- name: reload gpg-agent
+  command: gpgconf --reload gpg-agent
+  when: gpg_result is succeeded
+
+- name: start gpg-agent
+  command: gpg-agent --homedir {{ root_gpg_dir }} --use-standard-socket --daemon
+  when: gpg_result is failed
 
 - name: "Start the dirmngr"
   command: "dirmngr --homedir {{ root_gpg_dir }} --daemon"

--- a/playbooks/roles/gpg/tasks/main.yml
+++ b/playbooks/roles/gpg/tasks/main.yml
@@ -39,11 +39,8 @@
     group: root
     mode: 0750
 
-- name: "Ensure GPG agent is dead"
-  command: "gpgconf --kil gpg-agent"
-
-- name: "Start the GPG agent"
-  command: "gpg-agent --homedir {{ root_gpg_dir }} --use-standard-socket --daemon"
+- name: "Start the GPG agent if it's not already started"
+  command: "pgrep gpg-agent || gpg-agent --homedir {{ root_gpg_dir }} --use-standard-socket --daemon && gpgconf --reload gpg-agent"
 
 - name: "Start the dirmngr"
   command: "dirmngr --homedir {{ root_gpg_dir }} --daemon"


### PR DESCRIPTION
checks for the status of gpg-agent to see if it is running or not and then act accordingly