### PR TITLE
wireguard: remove awkward client/server notation

### DIFF
--- a/playbooks/roles/test-client/tasks/wireguard-profiletest.yml
+++ b/playbooks/roles/test-client/tasks/wireguard-profiletest.yml
@@ -1,17 +1,17 @@
 ---
 - block:
-    - name: "Replace wg0-client with the {{ profile_name }} configuration"
+    - name: "Replace wg0 with the {{ profile_name }} configuration"
       copy:
-        src: "{{ wireguard_profile_dir }}/{{ profile_name }}.client.conf"
+        src: "{{ wireguard_profile_dir }}/{{ profile_name }}.conf"
         remote_src: yes
-        dest: "/etc/wireguard/wg0-client.conf"
+        dest: "/etc/wireguard/wg0.conf"
         mode: 0600
         owner: root
         group: root
         force: yes
 
     - name: "Bring up the WireGuard interface for the {{ profile_name }} config"
-      shell: "wg-quick up wg0-client"
+      shell: "wg-quick up wg0"
 
     - name: "Register the updated /etc/resolv.conf contents"
       shell: "cat /etc/resolv.conf"
@@ -40,7 +40,7 @@
           - "'latest handshake' in wgclient_wg_output.stdout"
 
     - name: "Bring down the WireGuard interface"
-      command: "wg-quick down wg0-client"
+      command: "wg-quick down wg0"
 
     - name: "Register the updated /etc/resolv.conf contents"
       shell: "cat /etc/resolv.conf"
@@ -52,6 +52,6 @@
         that:
           - "'nameserver {{ dnsmasq_wireguard_ip }}' not in wgclient_resolv_conf.stdout"
   rescue:
-    - name: "Remove the wg0-client interface if present"
-      command: "wg-quick down wg0-client"
+    - name: "Remove the wg0 interface if present"
+      command: "wg-quick down wg0"
       ignore_errors: "yes"

--- a/playbooks/roles/test-client/tasks/wireguard.yml
+++ b/playbooks/roles/test-client/tasks/wireguard.yml
@@ -18,8 +18,8 @@
 
 - name: "Download each of the WireGuard client profiles"
   get_url:
-    url: "{{ gateway_test_url }}/wireguard/{{ profile_name }}.client.conf"
-    dest: "{{ wireguard_profile_dir }}/{{ profile_name }}.client.conf"
+    url: "{{ gateway_test_url }}/wireguard/{{ profile_name }}.conf"
+    dest: "{{ wireguard_profile_dir }}/{{ profile_name }}.conf"
     force_basic_auth: yes
     url_username: "{{ gateway_test_user }}"
     url_password: "{{ lookup('file', '{{ streisand_gateway_password_localpath }}') }}"

--- a/playbooks/roles/test-client/vars/main.yml
+++ b/playbooks/roles/test-client/vars/main.yml
@@ -54,7 +54,7 @@ shadowsocks_client: "/root/shadowsocks2-linux-x64"
 shadowsocks_client_zip: "{{ shadowsocks_client }}.gz"
 
 # The gateway URL for clients to download the WireGuard config file
-gateway_wireguard_config: "{{ gateway_test_url }}/wireguard/wg0-client.conf"
+gateway_wireguard_config: "{{ gateway_test_url }}/wireguard/wg0.conf"
 
 wireguard_profile_dir: "/root/wireguard-profiles"
 

--- a/playbooks/roles/wireguard/tasks/docs.yml
+++ b/playbooks/roles/wireguard/tasks/docs.yml
@@ -8,9 +8,9 @@
     state: directory
 
 - name: Copy the client configuration files to the WireGuard Gateway directory
-  command: "cp {{ wireguard_client_path }}/{{ client_name.stdout }}/client.conf {{ wireguard_gateway_location }}/{{ client_name.stdout }}.client.conf"
+  command: "cp {{ wireguard_client_path }}/{{ client_name.stdout }}/client.conf {{ wireguard_gateway_location }}/{{ client_name.stdout }}.conf"
   args:
-    creates: "{{ wireguard_gateway_location }}/{{ client_name.stdout }}.client.conf"
+    creates: "{{ wireguard_gateway_location }}/{{ client_name.stdout }}.conf"
   with_items: "{{ vpn_client_names.results }}"
   loop_control:
     loop_var: "client_name"

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -86,7 +86,7 @@
 - name: Generate the server configuration
   template:
     src: "server.conf.j2"
-    dest: "{{ wireguard_path }}/wg0-server.conf"
+    dest: "{{ wireguard_path }}/wg0.conf"
     owner: root
     group: root
     mode: 0600
@@ -96,7 +96,7 @@
 
 - name: Enable the WireGuard service so it starts at boot, and bring up the WireGuard network interface
   systemd:
-    name: wg-quick@wg0-server.service
+    name: wg-quick@wg0.service
     enabled: yes
     state: started
   # Temporary workaround for issue #500

--- a/playbooks/roles/wireguard/templates/instructions-fr.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions-fr.md.j2
@@ -26,7 +26,7 @@ WireGuard n'est actuellement disponible que pour Linux, mais support [multi-plat
 
 1. Vous devriez être prêt à partir! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur DuckDuckGo]({{ streisand_my_ip_url }}). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
-1. Pour arrêter de routé votre trafic via Wire Guard, simplement arrêtez l'interface:
+1. Pour arrêter de routé votre trafic via WireGuard, simplement arrêtez l'interface:
 
    `sudo wg-quick down {{ vpn_client_names.results[0].stdout }}`
 

--- a/playbooks/roles/wireguard/templates/instructions-fr.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions-fr.md.j2
@@ -14,25 +14,21 @@ WireGuard n'est actuellement disponible que pour Linux, mais support [multi-plat
 1. [Installer WireGuard](https://www.wireguard.com/install/)
 1. Téléchargez un fichier de configuration client. **Un seul ordinateur peut utiliser un profil à la fois**. Pour cet exemple, nous supposerons que vous avez téléchargé le fichier {{ vpn_client_names.results[0].stdout }}:
 {% for client in vpn_client_names.results %}
-   * [{{ client.stdout }}](/wireguard/{{ client.stdout }}.client.conf)
+   * [{{ client.stdout }}](/wireguard/{{ client.stdout }}.conf)
 {% endfor %}
-1. Renommez le fichier:
-
-  `mv ~/Downloads/{{ vpn_client_names.results[0].stdout }}.client.conf ~/Downloads/wg0-client.conf`
-1. Définir les autorisations sur le fichier de configuration du client:
-
-   `sudo chown -v root:root ~/Downloads/wg0-client.conf; sudo chmod -v 600 ~/Downloads/wg0-client.conf`
 1. Déplacez le fichier de configuration du client dans le répertoire correct:
 
-   `sudo mv -i -v ~/Downloads/wg0-client.conf /etc/wireguard/`
+   `sudo sh -c 'umask 077; mkdir -p /etc/wireguard; cat > /etc/wireguard/{{ vpn_client_names.results[0].stdout }}.conf' < ~/Downloads/{{ vpn_client_names.results[0].stdout }}.conf`
+
 1. Utilisez l'utilitaire `wg-quick` pour démarrer l'interface WireGuard:
 
-   `sudo wg-quick up wg0-client`
+   `sudo wg-quick up {{ vpn_client_names.results[0].stdout }}`
+
 1. Vous devriez être prêt à partir! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur DuckDuckGo]({{ streisand_my_ip_url }}). Il devrait dire *Votre adresse IP publique est {{streisand_ipv4_address}}*.
 
 1. Pour arrêter de routé votre trafic via Wire Guard, simplement arrêtez l'interface:
 
-   `sudo wg-quick down wg0-client`
+   `sudo wg-quick down {{ vpn_client_names.results[0].stdout }}`
 
 #### Une note sur la configuration DNS ####
 Chaque fichier inclure la commande `DNS` qui utilise `resolvconf` afin de diriger le trafic DNS vers le serveur dnsmasq qui est disponible via l'interface cryptée WireGuard à `{{ dnsmasq_wireguard_ip }}`. Bien que `resolvconf` soit un utilitaire commun, vous devrez peut-être remplacer cette ligne avec `PostUp`/`PostDown` pour votre distribution ou votre configuration réseau particulière.

--- a/playbooks/roles/wireguard/templates/instructions.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions.md.j2
@@ -14,29 +14,24 @@ WireGuard is currently only available for Linux, but [cross-platform](https://ww
 1. [Install WireGuard](https://www.wireguard.com/install/)
 1. Download one of the client configuration files. **Only one computer can use a profile at a time**. For this example we'll assume you downloaded {{ vpn_client_names.results[0].stdout }}:
 {% for client in vpn_client_names.results %}
-   * [{{ client.stdout }}](/wireguard/{{ client.stdout }}.client.conf)
+   * [{{ client.stdout }}](/wireguard/{{ client.stdout }}.conf)
 {% endfor %}
-1. Rename the downloaded client configuration:
-
-  `mv ~/Downloads/{{ vpn_client_names.results[0].stdout }}.client.conf ~/Downloads/wg0-client.conf`
-1. Set permissions on the client configuration file:
-
-   `sudo chown -v root:root ~/Downloads/wg0-client.conf; sudo chmod -v 600 ~/Downloads/wg0-client.conf`
 1. Move the client configuration file into the correct directory:
 
-   `sudo mv -i -v ~/Downloads/wg0-client.conf /etc/wireguard/`
+   `sudo sh -c 'umask 077; mkdir -p /etc/wireguard; cat > /etc/wireguard/{{ vpn_client_names.results[0].stdout }}.conf' < ~/Downloads/{{ vpn_client_names.results[0].stdout }}.conf`
+
 1. Use the `wg-quick` utility to bring up the WireGuard interface:
 
-   `sudo wg-quick up wg0-client`
+   `sudo wg-quick up {{ vpn_client_names.results[0].stdout }}`
 
 1. For Linux systems using systemd you can also enable Wireguard at boot:
 
-   'sudo systemctl enable wg-quick@wg0-client.service'
+   'sudo systemctl enable wg-quick@{{ vpn_client_names.results[0].stdout }}.service'
 
 1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on DuckDuckGo]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 1. To stop routing your traffic through WireGuard, simply bring the interface back down:
 
-   `sudo wg-quick down wg0-client`
+   `sudo wg-quick down {{ vpn_client_names.results[0].stdout }}`
 
 #### A note on DNS configuration ####
 Each client configuration profile includes a `DNS` command that uses resolvconf to direct DNS traffic to the dnsmasq server that is available via the WireGuard encrypted interface at `{{ dnsmasq_wireguard_ip }}`. Although resolvconf is a common utility, you may need to use `PostUp`/`PostDown` with a different command for your distribution or particular network configuration.


### PR DESCRIPTION
This had with it a few problems. Some versions of android don't like
config files with a dot in them, it would increase the length of the
interface beyond what it should be, and generally this belies the real
architecture of wireguard. Instead, call test interfaces and the server
interfaces 'wg0' and call each client interface by its profile name
alone.

While we're at it, we clean up the instructions a bit.

----------

This commit is entirely untested.