### PR TITLE
Change install instructions to use virtualenv './venv'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ inventories/inventory-existing
 
 # Ignore the Streisand diagnostics file we generate each run
 streisand-diagnostics.md
+
+# We recommend people use a Python virtualenv, and document this as
+# the location.
+venv/

--- a/README.md
+++ b/README.md
@@ -105,73 +105,39 @@ Complete all of these tasks on your local home machine.
         ssh-keygen
   * If you'd like to use an SSH key with a different name or in a non-standard location, please enter 'yes' when asked if you'd like to customize your instance during installation.
   * **Please note**: You will need these keys to access your Streisand instance over SSH. Please keep them for the lifetime of the Streisand server.
-* Install Git.
+### Bootstrap ###
+* Install the bootstrap packages: Git, and `pip` for Python 2.7.
+
   * On Debian and Ubuntu
 
-        sudo apt-get install git
-  * On Fedora
+        sudo apt-get install git python-pip
+  * On Fedora 27, some additional packages are needed later.
 
-        sudo yum install git
-  * On macOS (via [Homebrew](https://brew.sh/))
+		sudo yum install git python2-pip gcc python2-devel python2-crypto python2-pycurl libcurl-devel
+  * On macOS, `git` is part of the Developer Tools, and it will be installed the first time you run it. If there isn't already a `pip` command installed, install it with:
 
-        brew install git
-* Install the [pip](https://pip.pypa.io/en/latest/) package management system for Python.
-  * On Debian and Ubuntu (also installs the dependencies that are necessary to build Ansible and that are required by some modules)
-
-        sudo apt-get install python-paramiko python-pip python-pycurl python-dev build-essential
-  * On Fedora
-
-        sudo yum install python-pip
-  * On macOS
-
-        sudo easy_install pip
-        sudo pip install pycurl
-
-* Install [Ansible](https://www.ansible.com/).
-  * On macOS (via [Homebrew](https://brew.sh/))
-
-        brew install ansible
-  * On BSD or Linux (via pip)
-
-        sudo pip install ansible markupsafe
-* Install the necessary Python libraries for your chosen cloud provider. If you
-    are using the advanced local provisioning mode or the existing server mode
-    you can skip this section.
-  * Amazon EC2
-
-        sudo pip install boto boto3
-  * Azure
-
-        sudo pip install ansible[azure]
-  * DigitalOcean
-
-        sudo pip install dopy==0.3.5
-  * Google
-
-        sudo pip install "apache-libcloud>=1.17.0"
-
-  * Linode
-
-        sudo pip install linode-python
-  * Rackspace Cloud
-
-        sudo pip install pyrax
-  * **Important note if you are using a Homebrew-installed version of Python** you should also run these commands to make sure it can find the necessary libraries:
-
-        mkdir -p ~/Library/Python/2.7/lib/python/site-packages
-        echo '/usr/local/lib/python2.7/site-packages' > ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+        sudo python2.7 -m ensurepip
 
 ### Execution ###
 1. Clone the Streisand repository and enter the directory.
 
-       git clone https://github.com/StreisandEffect/streisand.git && cd streisand
+        git clone https://github.com/StreisandEffect/streisand.git && cd streisand
 
-2. Execute the Streisand script.
+2. Run the installer for Ansible and its dependencies.
 
-       ./streisand
-3. Follow the prompts to choose your provider, the physical region for the server, and its name. You will also be asked to enter API information.
-4. Once login information and API keys are entered, Streisand will begin spinning up a new remote server.
-5. Wait for the setup to complete (this usually takes around ten minutes) and look for the corresponding files in the 'generated-docs' folder in the Streisand repository directory. The HTML file will explain how to connect to the Gateway over SSL, or via the Tor hidden service. All instructions, files, mirrored clients, and keys for the new server can then be found on the Gateway. You are all done!
+        ./util/venv-dependencies.sh ./venv
+  * On Debian and Ubuntu, it may be necessary to install some additional packages. The installer will detect this, and print the command to run to install the packages.
+
+3. Activate the Ansible packages that were installed.
+
+        source ./venv/bin/activate
+
+4. Execute the Streisand script.
+
+        ./streisand
+5. Follow the prompts to choose your provider, the physical region for the server, and its name. You will also be asked to enter API information.
+5. Once login information and API keys are entered, Streisand will begin spinning up a new remote server.
+6. Wait for the setup to complete (this usually takes around ten minutes) and look for the corresponding files in the 'generated-docs' folder in the Streisand repository directory. The HTML file will explain how to connect to the Gateway over SSL, or via the Tor hidden service. All instructions, files, mirrored clients, and keys for the new server can then be found on the Gateway. You are all done!
 
 ### Running Streisand to Provision Localhost (Advanced) ###
 

--- a/util/venv-dependencies.sh
+++ b/util/venv-dependencies.sh
@@ -16,26 +16,21 @@ quiet=
 
 usage () {
        echo "
-Usage: $0 new-directory
+Usage: $0 ./venv
 
-This script installs Streisand builder dependencies into an isolated
-Python virtualenv. A virtualenv is one of the most reliable ways of
-avoiding version clashes, and is especially recommended for people
-having problems with initial Streisand installs.
+This script creates an isolated Python virtualenv at './venv', and
+installs Ansible and dependencies into it.
 
-Note that this script is not guaranteed to work for localhost
-deployments. This will be fixed in a later release.
+The script depends on Python 2.7, and on a functional 'pip' command.
+This script can install 'virtualenv' for you, but this may require
+sudo/root access.
 
-It depends on Python 2.7, and on a pip command functional enough to
-install virtualenv.  If this is a system running Debian or Ubuntu,
-this script will also check for other packages needed to install.
+If this system is running Debian or Ubuntu, this script will also
+check for other packages needed to install.
 
-This script can install virtualenv for you, but on Linux, this
-requires sudo/root access.
-
-'new-directory' must be somewhere you can write to. A good place may be
-$HOME/streisand-deps. If it already exists,
-please delete the directory, or use a different name.
+Although './venv' is recommended, you can specify another location to
+create the virtualenv. If the location already exists, it should be an
+existing virtualenv to overwrite.
 
 "
 }
@@ -155,9 +150,8 @@ parent_dirname="$(dirname "$1")"
 
 if [ ! -d "$parent_dirname" ]; then
     die "
-The parent directory of $1 ($parent_dirname) does not exist. Please specify a
-parent directory you can write to. $HOME/streisand-deps
-may be a good choice.
+The parent directory of $1 ($parent_dirname) does not exist. Please
+specify a parent directory you can write to. './venv' is a good choice.
 
 "
 fi
@@ -165,19 +159,27 @@ fi
 if [ ! -w "$parent_dirname" ]; then
     die "
 The parent directory of $1 ($parent_dirname) is not writable. Please specify a
-parent directory you can write to. $HOME/streisand-deps
-may be a good choice.
+parent directory you can write to. './venv' is a good choice.
 
 "
 fi
 
+# The virtualenv directory should be created from scratch. But if the
+# directory already exists *and* it looks like it was a virtualenv,
+# don't pester the user; just use "virtualenv --clear" to clean it out.
+
+# In any case, this script will not run "rm -rf $1", regardless of how
+# tempting.
+
 if [ -e "$1" ]; then
-    die "
-$1 already exists. Please specify a place for a
-new directory to be created. $HOME/streisand-deps
-is a good choice if it doesn't exist.
+    if [ ! -e "$1/bin/activate.csh" ]; then
+	die "
+The directory $1 already exists, and it does not appear to contain a
+Python virtualenv. Please specify a new directory to be
+created. './venv' is a good choice if it doesn't exist.
 
 "
+    fi
 fi
 
 sudo_pip () {
@@ -213,7 +215,7 @@ fi
 # In case we have a new virtualenv executable.
 hash -r
 
-if ! virtualenv --python=python2.7 $NO_SITE_PACKAGES "$1"; then
+if ! virtualenv --python=python2.7 --clear $NO_SITE_PACKAGES "$1"; then
     parent_dirname="$(dirname "$1")"
     echo "
 virtualenv failed to create directory '$1'
@@ -221,8 +223,8 @@ using 'virtualenv --python=python2.7 $1'. Note that $1 must not exist, but
 its parent ($parent_dirname) must exist.
 
 The first argument, 'new-directory', must be somewhere you can write
-to. A good place may be $HOME/streisand-deps. If it already exists,
-please delete the directory, or use a different name.
+to. A good place is './venv'. If it already exists, please delete the
+directory, or use a different name.
 
 "
     exit 1


### PR DESCRIPTION
Explaining how to set things up with virtualenvs is easier. Using a single location is easier still. What kept me from doing this before was deciding how to clean out a location which already existed. Now check for the existence of a `$TARGET/bin/activate.csh`. If that exists, it's pretty likely $TARGET was a virtualenv, and it won't hurt to do an install into it using `--clear`.