### PR TITLE
CI: Remove explicit LXC network profile attach.

### DIFF
--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -80,9 +80,6 @@
     - name: lxd create network
       command: lxc network create testbr0
 
-    - name: lxd attach network to default profile
-      command: lxc network attach-profile testbr0 default eth0
-
     - name: Retrieve the Ubuntu Xenial AMD64 LXC image fingerprint
       uri:
         url: https://images.linuxcontainers.org/1.0/images/aliases/ubuntu/xenial/amd64


### PR DESCRIPTION
In CI the `tests/development-setup.yml` tasks eventually run `lxc network attach-profile testbr0 default eth0`. Recently this has errored because `eth0` already exists. In the process of debugging I noticed things Just Work (TM) if this `attach-profile` step is skipped entirely.

This commit removes the `lxc network attach-profile` command from `test/development-setup.yml` and CI stops failing.