### PR TITLE
Ansible 2.5.4 works OK; roll back pycurl version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,7 @@
 
 # Core with Azure dependencies
 #
-# Quick fix: Ansible 2.5.1 is broken; use 2.5.0 until at least version
-# 2.5.2 is released.
-#
-ansible[azure]==2.5.2
+ansible[azure]==2.5.4
 
 # Multiple packages depend on SecretStorage, and versions >= 3 require
 # Python 3. Until we're ready for Python 3, specify the earlier rev.
@@ -32,8 +29,11 @@ apache-libcloud>=1.17.0
 pycrypto
 
 # Linode
-pycurl
-linode-python
+#
+# Temporarily disabled while the pycurl mess is cleaned up.
+#
+# pycurl
+# linode-python
 
 # Rackspace
 pyrax

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,11 +29,8 @@ apache-libcloud>=1.17.0
 pycrypto
 
 # Linode
-#
-# Temporarily disabled while the pycurl mess is cleaned up.
-#
-# pycurl
-# linode-python
+pycurl==7.43.0.1
+linode-python
 
 # Rackspace
 pyrax


### PR DESCRIPTION
GCE appears to work with Ansible 2.5.4, which hasn't been true for several versions.

pycurl from PyPI now requires lots of fiddling and compile-time dependencies. Temporarily disable it in `requirements.txt` to keep it from breaking everyone else.