### PR TITLE
Generate OpenWrt WireGuard profiles and instructions

### DIFF
--- a/playbooks/roles/wireguard/tasks/docs.yml
+++ b/playbooks/roles/wireguard/tasks/docs.yml
@@ -16,6 +16,16 @@
     loop_var: "client_name"
     label: "{{ client_name.item }}"
 
+- name: Copy the client OpenWrt configuration fragments to the WireGuard Gateway directory
+  command: "cp {{ wireguard_client_path }}/{{ client_name.stdout }}/client-openwrt.txt {{ wireguard_gateway_location }}/{{ client_name.stdout }}-openwrt.txt"
+  args:
+    creates: "{{ wireguard_gateway_location }}/{{ client_name.stdout }}-openwrt.txt"
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
+
+
 - include_role:
     name: i18n-docs
   vars:

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -83,6 +83,16 @@
   loop_control:
     label: "{{ item[0].item }}"
 
+- name: Generate OpenWrt configuration fragments
+  template:
+    src: client-openwrt.txt.j2
+    dest: "{{ wireguard_client_path }}/{{ item[0].stdout }}/client-openwrt.txt"
+  with_together:
+    - "{{ vpn_client_names.results }}"
+    - "{{ wireguard_client_privkeys.results }}"
+  loop_control:
+    label: "{{ item[0].item }}"
+
 - name: Generate the server configuration
   template:
     src: "server.conf.j2"

--- a/playbooks/roles/wireguard/templates/client-openwrt.txt.j2
+++ b/playbooks/roles/wireguard/templates/client-openwrt.txt.j2
@@ -18,7 +18,7 @@
 
 ############
 
-# If aren't using LuCI, you need the "kmod-wireguard" and
+# If you aren't using LuCI, you need the "kmod-wireguard" and
 # "wireguard-tools" packages. You may need to reboot after running
 # this script (just restarting /etc/init.d/network may not be enough.)
 

--- a/playbooks/roles/wireguard/templates/client-openwrt.txt.j2
+++ b/playbooks/roles/wireguard/templates/client-openwrt.txt.j2
@@ -1,0 +1,116 @@
+### START-WIREGUARD
+
+# This OpenWrt (LEDE) /etc/rc.local script sets up the WireGuard profile
+# "{{ item[0].stdout }}" from the "{{ streisand_server_name }}" Streisand server.
+
+# Note that this script will replace the router's Internet access;
+# only run it when you're connected to the LAN/WiFi connection.
+
+# Open the LuCI web admin interface to the "System:Startup" page.
+# Paste this whole file into the "Local Startup" box. During the next
+# reboot, the script will run, and erase itself. It will leave a
+# success/failure message in the "Local Startup" box.
+
+# If you're using the web admin UI, you need the "luci-app-wireguard"
+# and "luci-proto-wireguard" packages installed.
+
+# LuCI instructions end here.
+
+############
+
+# If aren't using LuCI, you need the "kmod-wireguard" and
+# "wireguard-tools" packages. You may need to reboot after running
+# this script (just restarting /etc/init.d/network may not be enough.)
+
+# Commenting out the next line will stop this script from messing
+# around with /etc/rc.local.
+
+trap self_cleanup 0
+
+# Instructions end here.
+
+################################################################
+
+# Make errors fatal.
+set -e
+
+wireguard_completed="# Wireguard setup did not complete."
+
+self_cleanup () {
+    sed -i.bak -e '/^### START-WIREGUARD/,/^### END-WIREGUARD/ d' \
+               -e "\$ a $wireguard_completed" \
+        /etc/rc.local
+}
+
+. /lib/functions.sh
+
+# This should be rewritten in terms of /lib/functions.sh callbacks.
+move_to_firewall_zone () {
+    ifname="$1"
+    fwzone="$2"
+    for i in $(seq 0 20); do
+	# No more zones?
+	name=$(uci get "firewall.@zone[$i].name" 2>/dev/null) || return
+	networks=$(uci get "firewall.@zone[$i].network")
+	if list_contains networks "$ifname"; then
+	    # Shell programmer wanted.
+	    networks=$(echo "$networks" | sed "s/ *\\b${ifname}\\b *//")
+	fi
+	if [ "$name" = "$fwzone" ]; then
+	    append networks "$ifname"
+	fi
+	uci set "firewall.@zone[$i].network=$networks"
+    done
+}
+
+ifname="{{ item[0].stdout | replace("-", "_") }}"
+
+if ! uci get "network.$ifname" >/dev/null 2>&1; then
+    # Clean out any old peers
+    uci delete "network.@wireguard_$ifname[0]" >/dev/null 2>&1 || true
+
+    uci batch <<EOF
+
+
+# The local interface
+set network.$ifname=interface
+
+set network.$ifname.proto='wireguard'
+set network.$ifname.private_key='{{ item[1].stdout }}'
+set network.$ifname.addresses='10.192.122.{{ (item[0].item|int) + 1 }}/32'
+set network.$ifname.listen_port='51820'
+
+# The remote peer, i.e., the Streisand server
+add network wireguard_$ifname
+
+set network.@wireguard_$ifname[-1].public_key='{{ wireguard_server_public_key }}'
+set network.@wireguard_$ifname[-1].endpoint_host='{{ streisand_ipv4_address }}'
+set network.@wireguard_$ifname[-1].endpoint_port='{{ wireguard_port }}'
+
+# Route *everything* through this peer.
+add_list network.@wireguard_$ifname[-1].allowed_ips='0.0.0.0/0'
+set network.@wireguard_$ifname[-1].route_allowed_ips='1'
+
+# It is much more painful to debug when this is needed but missing.
+set network.@wireguard_$ifname[-1].persistent_keepalive='25'
+
+
+EOF
+
+    move_to_firewall_zone "$ifname" wan || true # FIXME
+
+    # Set the system-wide DNS
+    uci delete dhcp.@dnsmasq[0].server || true
+    uci add_list dhcp.@dnsmasq[0].server=10.192.122.1
+    uci set dhcp.@dnsmasq[0].noresolv=1
+
+    uci commit
+    # This seems necessary, and a full reboot may be as well.
+    /etc/init.d/network restart
+fi
+
+wireguard_completed="# Wireguard interface configured successfully"
+
+### END-WIREGUARD
+#
+# Status

--- a/playbooks/roles/wireguard/templates/instructions.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions.md.j2
@@ -7,6 +7,8 @@ If you are a Linux user, [WireGuard](https://www.wireguard.com/) is almost certa
 
 WireGuard is currently only available for Linux, but [cross-platform](https://www.wireguard.com/xplatform/) and portable implementations are under active development.
 
+An [experimental configuration for OpenWrt/LEDE](#openwrt) 17.01.4 or later is available.
+
 ---
 
 <a name="linux"></a>
@@ -35,3 +37,51 @@ WireGuard is currently only available for Linux, but [cross-platform](https://ww
 
 #### A note on DNS configuration ####
 Each client configuration profile includes a `DNS` command that uses resolvconf to direct DNS traffic to the dnsmasq server that is available via the WireGuard encrypted interface at `{{ dnsmasq_wireguard_ip }}`. Although resolvconf is a common utility, you may need to use `PostUp`/`PostDown` with a different command for your distribution or particular network configuration.
+
+---
+
+<a name="openwrt"></a>
+### EXPERIMENTAL: OpenWrt (LEDE) ###
+
+As an **unsupported** experiment, these profiles are available for routers running [OpenWrt](https://openwrt.org/). Support requires OpenWrt/LEDE 17.01.4 or later; OpenWrt Chaos Calmer is too old.
+
+OpenWrt devices run Linux, but they're managed through a centralized configuration system called [UCI](https://openwrt.org/docs/guide-user/base-system/uci). Most OpenWrt devices have a web admin interface called LuCI, which hides the complexity of UCI. These WireGuard profiles can be installed through a shell, or through the LuCI web interface.
+
+These profiles will replace the existing Internet connection. As a result, you should only install them when you're connected to the router's WiFi or LAN network interface. If you're logged in remotely, you may be locked out.
+
+#### Installing WireGuard software ####
+
+Make sure these software packages are installed: `luci-app-wireguard` and `luci-proto-wireguard`. To install those packages from the web UI:
+
+1. Go to the LuCI *System:Software* page, and click the *Update lists* button.
+2. Type `wireguard` into the *Find package* box.
+3. Click on the *Available packages (wireguard)* tab.
+4. Click *Install* next to `luci-app-wireguard`; go back to step 2 to install `luci-proto-wireguard` as well.
+
+(If you're managing your router without the LuCI user interface, you can instead `opkg update; opkg install kmod-wireguard wireguard-tools` .)
+
+#### Installing the profile ####
+
+Experienced users can install these profiles from the router's SSH command line; place one in a file, and run it as a shell script.
+
+There's also a simple way to install via the web interface. The LuCI *System:Startup* web page contains a *Local Startup* text box. It's a shell script which is run each time the router boots up. These WireGuard profiles are designed to be pasted into the *Local Startup* box, replacing the existing contents. (Make sure to delete any `exit 0` lines.)
+
+The next time the router reboots, the script will be run. It removes itself automatically. Check the *Local Startup* box for the status result.
+
+#### Changes made by the profile ####
+
+* A new interface named like `poem_walk` will be created
+* The interface is added to the *WAN* network zone
+* The default route to the Internet is set to the interface. (This will break WAN connectivity, so be sure to install only from WiFi/LAN.)
+* The WireGuard keepalive is set to 25 seconds
+* System-wide DNS is forced to point at the Streisand server
+
+If you don't like the DNS default, you can change DNS behavior on the *Network:DHCP and DNS* LuCI page. Put the DNS server address in *DNS forwardings*. On the *Resolv and Hosts Files* tab, leave *Ignore resolve file* checked, unless you want to use your upstream DNS. (You probably don't.)
+
+If you know you aren't behind a NAT device, edit the WireGuard interface to set the keepalive to 0.
+
+#### OpenWrt Profiles ####
+
+{% for client in vpn_client_names.results %}
+   * [{{ client.stdout }}](/wireguard/{{ client.stdout }}-openwrt.txt)
+{% endfor %}

--- a/playbooks/roles/wireguard/templates/instructions.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions.md.j2
@@ -14,7 +14,7 @@ An [experimental configuration for OpenWrt/LEDE](#openwrt) 17.01.4 or later is a
 * Platforms
   * [Linux](#linux)
   * [macOS](#macos)
-  
+  * [OpenWrt](#openwrt)
 ---
 
 <a name="linux"></a>

--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -80,9 +80,6 @@
     - name: lxd create network
       command: lxc network create testbr0
 
-    - name: lxd attach network to default profile
-      command: lxc network attach-profile testbr0 default eth0
-
     - name: Retrieve the Ubuntu Xenial AMD64 LXC image fingerprint
       uri:
         url: https://images.linuxcontainers.org/1.0/images/aliases/ubuntu/xenial/amd64


### PR DESCRIPTION
There's been some interest in OpenWrt/LEDE support for WireGuard. This adds profiles and full (?) documentation. Works on OpenWrt devices from LEDE 17.01.4 and newer.