### PR TITLE
Added .reload-module-on-update to make wireguard upgrades fully unattended

### DIFF
--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -91,6 +91,11 @@
     group: root
     mode: 0600
 
+- name: Enable reload-module-on-update to upgrade Wireguard without user confirmation
+  file:
+    path: "{{ wireguard_path }}/.reload-module-on-update"
+    state: touch
+    
 # Set up the WireGuard firewall rules
 - import_tasks: firewall.yml
 

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -95,7 +95,7 @@
   file:
     path: "{{ wireguard_path }}/.reload-module-on-update"
     state: touch
-    
+
 # Set up the WireGuard firewall rules
 - import_tasks: firewall.yml
 


### PR DESCRIPTION
Related to WireGuard not fully upgraded on the fly #1374