### PR TITLE
Remove "ec2:DescribeAlarms" from suggested IAM policy

### DIFF
--- a/documentation/AWS.md
+++ b/documentation/AWS.md
@@ -30,7 +30,6 @@ IAM Policy Setup
                 "ec2:CreateSecurityGroup",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeAddresses",
-                "ec2:DescribeAlarms",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
                 "ec2:DescribeKeyPairs",


### PR DESCRIPTION
Hello!

In the suggested AWS IAM policy in the documentation, both `"ec2:DescribeAlarms"` and `"cloudwatch:DescribeAlarms"` are included. `"ec2:DescribeAlarms"` generates an error in IAM as the `DescribeAlarms` action doesn't exist for `ec2`. From some research, it seems like this was probably just included as a mistake.

Thank you! Keep up the great work, I rely on this project and appreciate all you do.