### PR TITLE
Don't print long apt keys to the log

### DIFF
--- a/playbooks/roles/lets-encrypt/tasks/install.yml
+++ b/playbooks/roles/lets-encrypt/tasks/install.yml
@@ -3,6 +3,7 @@
     id: 9862409EF124EC763B84972FF5AC9651EDB58DFA
     data: "{{ item }}"
   with_file: acmetool_ppa.pem
+  no_log: True
 
 - name: Add the official acmetool repository
   apt_repository:

--- a/playbooks/roles/lets-encrypt/tasks/install.yml
+++ b/playbooks/roles/lets-encrypt/tasks/install.yml
@@ -1,4 +1,4 @@
-- name: Add the APT key for acmetool
+- name: "Add the APT key for acmetool; hiding 25 lines of log..."
   apt_key:
     id: 9862409EF124EC763B84972FF5AC9651EDB58DFA
     data: "{{ item }}"

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -5,7 +5,7 @@
     state: absent
   with_items: "{{ apache_packages_to_remove }}"
 
-- name: Add the official Nginx APT key
+- name: "Add the official Nginx APT key; hiding 25 lines of log..."
   apt_key:
     id: 7BD9BF62
     data: "{{ item }}"

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -10,6 +10,7 @@
     id: 7BD9BF62
     data: "{{ item }}"
   with_file: nginx_signing.key
+  no_log: True
 
 - name: Add the official Nginx repository
   apt_repository:

--- a/playbooks/roles/openvpn/tasks/install.yml
+++ b/playbooks/roles/openvpn/tasks/install.yml
@@ -1,9 +1,10 @@
 ---
-- name: Add the official OpenVPN APT key
+- name: "Add the official OpenVPN APT key; hiding 25 lines of log..."
   apt_key:
     id: E158C569
     data: "{{ item }}"
   with_file: openvpn_signing.key
+  no_log: True
 
 - name: Add the official OpenVPN repository
   apt_repository:

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
-- name: Add the Tor APT key
+- name: "Add the Tor APT key; hiding 200 lines of log..."
   apt_key:
     id: 886DDD89
     data: "{{ item }}"
   with_file: tor-signing.key
+  no_log: True
 
 - name: Add the Tor repository
   apt_repository:


### PR DESCRIPTION
This is mostly for the 200-line Tor key, but the other (25-line) keys were hidden for consistency.