### PR TITLE
Fix stunnel windows mirror download location

### DIFF
--- a/playbooks/roles/stunnel/vars/mirror.yml
+++ b/playbooks/roles/stunnel/vars/mirror.yml
@@ -6,13 +6,13 @@ stunnel_mirror_href_base: "/mirror/stunnel"
 
 stunnel_base_download_url: "https://www.stunnel.org"
 
-stunnel_installer_filename: "stunnel-{{ stunnel_version }}-win32-installer.exe"
+stunnel_installer_url: "stunnel-latest-installer.exe"
+stunnel_installer_sig_url: "stunnel-latest-installer.exe.asc"
+
+stunnel_installer_filename: "{{ stunnel_installer_url }}"
 stunnel_installer_sig_filename: "{{ stunnel_installer_filename }}.asc"
 stunnel_installer_href: "{{ stunnel_mirror_href_base }}/{{ stunnel_installer_filename }}"
 stunnel_installer_sig_href: "{{ stunnel_mirror_href_base }}/{{ stunnel_installer_sig_filename }}"
-
-stunnel_installer_url: "stunnel-latest-installer.exe"
-stunnel_installer_sig_url: "stunnel-latest-installer.exe.asc"
 
 stunnel_source_filename: "stunnel-{{ stunnel_version }}.tar.gz"
 stunnel_source_sig_filename: "{{ stunnel_source_filename }}.asc"


### PR DESCRIPTION
The documentation at ```https://vpn.example.org/mirror/stunnel/index.html``` points to 
```https://vpn.example.org/mirror/stunnel/stunnel-latest-win32-installer.exe``` for the Windows
installer. 

The downloaded file however is named ```stunnel-latest-installer.exe```:
```
root@test6-localhost:/var/www/streisand/mirror/stunnel# pwd
/var/www/streisand/mirror/stunnel
root@test6-localhost:/var/www/streisand/mirror/stunnel# ls -l
total 3784
-rwxr-x--- 1 www-data www-data    6367 Aug  9 15:08 index-fr.html
-rwxr-x--- 1 www-data www-data     414 Aug  9 15:08 index-fr.md
-rwxr-x--- 1 www-data www-data    6367 Aug  9 15:08 index.html
-rwxr-x--- 1 www-data www-data     414 Aug  9 15:08 index.md
-rwxr-x--- 1 www-data www-data 3130792 Aug  9 15:08 stunnel-latest-installer.exe
-rwxr-x--- 1 www-data www-data     963 Aug  9 15:08 stunnel-latest-installer.exe.asc
-rwxr-x--- 1 www-data www-data  708356 Aug  9 15:08 stunnel-latest.tar.gz
-rwxr-x--- 1 www-data www-data     963 Aug  9 15:08 stunnel-latest.tar.gz.asc
```