### PR TITLE
Add instructions for OpenConnect app on Android.

### DIFF
--- a/playbooks/roles/openconnect/templates/instructions.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions.md.j2
@@ -117,6 +117,34 @@ Client certificates are a mechanism by which clients can authenticate themselves
 <a name="android"></a>
 ### Android ###
 
+1. Download the [server certificate](/openconnect/ca.crt) file.
+1. You will be prompted to enter your phone's PIN. Enter that.
+1. You will be prompted to *Name the certificate*. Tap the line under *Certificate name* and enter `{{ streisand_server_name }}`.
+1. Tap *OK*.
+1. Download a [client certificate file](#clientcerts) from the list above.
+1. Download [OpenConnect](https://play.google.com/store/apps/details?id=app.openconnect) from Google Play.
+1. Launch the application.
+1. Tap the *+* icon to add a new VPN.
+1. Enter `{{ streisand_ipv4_address }}:{{ ocserv_port }}`.
+1. Tap *User certificate*.
+1. Find the client certificate file you downloaded and tap it. Most likely it is in the Download folder if you downloaded it using the browser on your phone.
+1. Tap the *Select* button at the bottom of the screen.
+1. Tap *Private key*.
+1. Tap the same client certificate file you selected for *User certificate*.
+1. Tap the *Select* button at the bottom of the screen.
+1. Tap the Back button.
+1. You should see an entry under the *PROFILES* section.
+1. Tap that entry.
+1. First time only:
+  1. Accept the Connection Request dialog that Android displays.
+  1. Tou will be prompted *Enter PKCS#12 pass phrase:*. Enter the password from the client certificate that you downloaded.
+  1. You will be prompted *Certificate warning*. Tap *Always connect.*
+1. Each time you connect:
+  1. You will be prompted *Please select your group.* The correct default has already been chosen. Tap *OK*.
+1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on DuckDuckGo]({{ streisand_my_ip_url }}). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+
+Alternate instructions using Cisco AnyConnect, in case the above instructions fail:
+
 1. Download [Cisco AnyConnect](https://play.google.com/store/apps/details?id=com.cisco.anyconnect.vpn.android.avf) from Google Play.
 1. Launch the application.
 1. Tap *OK* to accept the "Supplemental End User License Agreement for AnyConnect&reg; Secure Mobility Client vx.x and other VPN-related Software".


### PR DESCRIPTION
The OpenConnect app has a few advantages over the Cisco AnyConnect:
 - Doesn't require agreeing to a EULA.
 - GPL'ed.
 - Can install a CA certificate rather than clicking through a
   certificate mismatch prompt.
 - Forward secrecy.
 - It doesn't appear to tickle the bug in #847 (prompting for a
   username).

For now, I kept the AnyConnect instructions, but I think if a number of
people are successful with these instructions, it would make sense to
provide instructions only for OpenConnect.

Fixes #1143.