### PR TITLE
Tor upstream is broken; disable it by default

### DIFF
--- a/global_vars/default-site.yml
+++ b/global_vars/default-site.yml
@@ -20,5 +20,5 @@ streisand_ssh_forward_enabled: yes
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_wireguard_enabled: yes

--- a/global_vars/integration/test-site.yml
+++ b/global_vars/integration/test-site.yml
@@ -16,7 +16,7 @@ streisand_ssh_forward_enabled: yes
 streisand_openvpn_enabled: yes
 streisand_wireguard_enabled: yes
 streisand_openconnect_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
 # TODO(@cpu): The services below need some manner of integration test written

--- a/global_vars/noninteractive/amazon-site.yml
+++ b/global_vars/noninteractive/amazon-site.yml
@@ -23,7 +23,7 @@ streisand_ssh_forward_enabled: yes
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_wireguard_enabled: yes
 
 # The AWS region number.

--- a/global_vars/noninteractive/azure-site.yml
+++ b/global_vars/noninteractive/azure-site.yml
@@ -23,7 +23,7 @@ streisand_ssh_forward_enabled: yes
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_wireguard_enabled: yes
 
 # The region to deploy into.

--- a/global_vars/noninteractive/digitalocean-site.yml
+++ b/global_vars/noninteractive/digitalocean-site.yml
@@ -27,7 +27,7 @@ streisand_ssh_forward_enabled: yes
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_wireguard_enabled: yes
 
 # The Digital Ocean region number.

--- a/global_vars/noninteractive/google-site.yml
+++ b/global_vars/noninteractive/google-site.yml
@@ -22,7 +22,7 @@ streisand_ssh_forward_enabled: yes
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_wireguard_enabled: yes
 
 # Server location:

--- a/global_vars/noninteractive/linode-site.yml
+++ b/global_vars/noninteractive/linode-site.yml
@@ -21,7 +21,7 @@ streisand_ssh_forward_enabled: yes
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_wireguard_enabled: yes
 
 # Choose the server location.

--- a/global_vars/noninteractive/local-site.yml
+++ b/global_vars/noninteractive/local-site.yml
@@ -22,7 +22,7 @@ streisand_ssh_forward_enabled: yes
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_wireguard_enabled: yes
 
 # Definitions needed for Let's Encrypt HTTPS (or TLS) certificate setup.

--- a/global_vars/noninteractive/rackspace-site.yml
+++ b/global_vars/noninteractive/rackspace-site.yml
@@ -21,7 +21,7 @@ streisand_ssh_forward_enabled: yes
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: yes
 streisand_tinyproxy_enabled: yes
-streisand_tor_enabled: yes
+streisand_tor_enabled: no
 streisand_wireguard_enabled: yes
 
 # Choose the region to deploy into.

--- a/playbooks/customize.yml
+++ b/playbooks/customize.yml
@@ -41,8 +41,8 @@
       default: "yes"
       private: no
     - name: streisand_tor_enabled
-      prompt: "Enable Tor? Press enter for default "
-      default: "yes"
+      prompt: "Enable Tor? (UPSTREAM IS BROKEN) Press enter for default "
+      default: "no"
       private: no
     - name: streisand_wireguard_enabled
       prompt: "Enable WireGuard? Press enter for default "


### PR DESCRIPTION
https://www.torproject.org/docs/debian.html.en says to install the deb.torproject.org-keyring package. Here's what happens:

```
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  deb.torproject.org-keyring
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 4922 B of archives.
After this operation, 22.5 kB of additional disk space will be used.
WARNING: The following packages cannot be authenticated!
  deb.torproject.org-keyring
```

Until we get enough time to figure this out, or upstream fixes it, disable the Tor bridge.

Resolves #1438.