### PR TITLE
Note Incompatible API keys from Linode Cloud Manager

### DIFF
--- a/playbooks/linode.yml
+++ b/playbooks/linode.yml
@@ -40,7 +40,7 @@
       private: no
 
     - name: "linode_api_key"
-      prompt: "\n\nThe following information can be found in the Linode Manager.\nhttps://manager.linode.com/profile/api\n\nNote: API keys originating from https://cloud.linode.com are not yet compatible\n.What is your Linode API key?\n"
+      prompt: "\n\nThe following information can be found in the Linode Manager.\nhttps://manager.linode.com/profile/api\n\nNote: API keys originating from https://cloud.linode.com/profile/tokens are not yet compatible.\n\nWhat is your Linode API key?\n"
       private: no
 
     - name: "confirmation"

--- a/playbooks/linode.yml
+++ b/playbooks/linode.yml
@@ -40,7 +40,7 @@
       private: no
 
     - name: "linode_api_key"
-      prompt: "\n\nThe following information can be found in the Linode Manager.\nhttps://manager.linode.com/profile/api\n\nWhat is your Linode API key?\n"
+      prompt: "\n\nThe following information can be found in the Linode Manager.\nhttps://manager.linode.com/profile/api\n\nNote: API keys originating from https://cloud.linode.com are not yet compatible\n.What is your Linode API key?\n"
       private: no
 
     - name: "confirmation"


### PR DESCRIPTION
* The Linode Ansible module uses the now deprecated Linode APIv3. APIv3 keys can still be generated from the page specified: https://manager.linode.com/profile/api , however, users of the beta Linode Manager (https://cloud.linode.com) may be unaware of the incompatibility of APIv4 tokens and Streisand. (https://github.com/StreisandEffect/streisand/issues/1449).  This PR adds a note to help avoid confusion.
