### PR TITLE
sslh Recommends apache2, which breaks acmetool redirector

### DIFF
--- a/playbooks/roles/sslh/tasks/main.yml
+++ b/playbooks/roles/sslh/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install sslh
   apt:
     name: sslh
+    install_recommends: false
 
 - name: Generate the sslh port multiplexer systemd defaults file
   template:


### PR DESCRIPTION
`sslh` now `Recommends: apache2 | httpd, openssh-server | ssh-server` and so it picks up `apache2`. This breaks the `acmetool` redirector, since it wants to be on 80 too. Let's not install those recommendations. We should consider turning off Recommendations system-wide.

Resolves #1329 (already resolved?). Resolves #1349. Resolves #1459. 