### PR TITLE
"apt:" stanza package reform

### DIFF
--- a/playbooks/provider-detect.yml
+++ b/playbooks/provider-detect.yml
@@ -13,7 +13,7 @@
   tasks:
     - name: "Install dmidecode to use for BIOS version detection"
       apt:
-        name: dmidecode
+        package: dmidecode
 
     - name: "Try to determine localhost Cloud provider name from BIOS version"
       # Looking into ways to detect EC2/GCE instances without relying on

--- a/playbooks/roles/common/tasks/detect-public-ip.yml
+++ b/playbooks/roles/common/tasks/detect-public-ip.yml
@@ -5,7 +5,7 @@
 # configuration profiles
 - name: "Install dns module"
   apt:
-    name: dnsutils
+    package: dnsutils
 
 - name: "Initialize lookup variable"
   set_fact:

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -14,16 +14,14 @@
 
 - name: Install Streisand common packages
   apt:
-    name: "{{ item }}"
-  with_items: "{{ streisand_common_packages }}"
+    package: "{{ streisand_common_packages }}"
 
 - name: Purge unneeded services
   apt:
-    name: "{{ item }}"
+    package: "{{ streisand_unneeded_packages }}"
     state: "absent"
     purge: yes
     autoremove: yes
-  with_items: "{{ streisand_unneeded_packages }}"
 
 - name: Perform a full system upgrade
   apt:

--- a/playbooks/roles/dnsmasq/tasks/main.yml
+++ b/playbooks/roles/dnsmasq/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Ensure that BIND is not installed in order to avoid conflicts with dnsmasq
   apt:
-    name: bind9
+    package: bind9
     state: absent
 
 - name: Install dnsmasq
   apt:
-    name: dnsmasq
+    package: dnsmasq
 
 - name: Generate the dnsmasq configuration file
   template:

--- a/playbooks/roles/gpg/tasks/main.yml
+++ b/playbooks/roles/gpg/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 - name: "Install GnuPG 2, dirmngr and gpgv2"
   apt:
-    name: "{{ item }}"
-  with_items:
-    - gnupg2
-    - dirmngr
-    - gpgv2
+    package:
+      - gnupg2
+      - dirmngr
+      - gpgv2
 
 - name: "Create the GPG directory"
   file:

--- a/playbooks/roles/lets-encrypt/tasks/install.yml
+++ b/playbooks/roles/lets-encrypt/tasks/install.yml
@@ -15,4 +15,4 @@
 
 - name: Install acmetool
   apt:
-    name: acmetool
+    package: acmetool

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -1,9 +1,8 @@
 ---
 - name: Ensure that the Apache web server is not installed in order to avoid conflicts with Nginx
   apt:
-    name: "{{ item }}"
+    package: "{{ apache_packages_to_remove }}"
     state: absent
-  with_items: "{{ apache_packages_to_remove }}"
 
 - name: "Add the official Nginx APT key; hiding 25 lines of log..."
   apt_key:
@@ -23,7 +22,7 @@
 
 - name: Install Nginx
   apt:
-    name: nginx
+    package: nginx
 
 - name: Update Nginx configuration
   copy:

--- a/playbooks/roles/openconnect/tasks/install.yml
+++ b/playbooks/roles/openconnect/tasks/install.yml
@@ -16,7 +16,7 @@
 
 - name: Install ocserv
   apt:
-    name: ocserv
+    package: ocserv
 
 - name: Create the OpenConnect rsyslog configuration directory
   file:

--- a/playbooks/roles/openvpn/tasks/install.yml
+++ b/playbooks/roles/openvpn/tasks/install.yml
@@ -17,7 +17,6 @@
 
 - name: Install OpenVPN and its dependencies from APT
   apt:
-    name: "{{ item }}"
-  with_items:
-    - openvpn
-    - udev
+    package:
+      - openvpn
+      - udev

--- a/playbooks/roles/shadowsocks/tasks/main.yml
+++ b/playbooks/roles/shadowsocks/tasks/main.yml
@@ -16,13 +16,12 @@
 
 - name: Install shadowsocks-libev
   apt:
-    name: "shadowsocks-libev"
+    package: "shadowsocks-libev"
 
 - name: Install the simple-obfs dependencies
   apt:
-    name: "{{ item }}"
+    package: "{{ shadowsocks_dependencies }}"
     install_recommends: no
-  with_items: "{{ shadowsocks_dependencies }}"
 
 - name: Create the shadowsocks-libev config directory
   file:

--- a/playbooks/roles/ssh-forward/tasks/docs.yml
+++ b/playbooks/roles/ssh-forward/tasks/docs.yml
@@ -21,7 +21,7 @@
 
 - name: Install the putty-tools package to facilitate converting the standard OpenSSH key into PuTTY's unique .ppk format
   apt:
-    name: putty-tools
+    package: putty-tools
 
 - name: Convert the OpenSSH key into a PuTTY .ppk
   command: puttygen {{ forward_location }}/.ssh/id_rsa -o {{ ssh_putty_rsa_key }}

--- a/playbooks/roles/sslh/tasks/main.yml
+++ b/playbooks/roles/sslh/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install sslh
   apt:
-    name: sslh
+    package: sslh
 
 - name: Generate the sslh port multiplexer systemd defaults file
   template:

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Install the required package for the htpasswd command
   apt:
-    name: apache2-utils
+    package: apache2-utils
 
 - name: Generate the htpasswd file
   command: htpasswd -b -c {{ streisand_gateway_htpasswd_file }} {{ streisand_gateway_username }} {{ streisand_gateway_password.stdout }}

--- a/playbooks/roles/stunnel/tasks/main.yml
+++ b/playbooks/roles/stunnel/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install stunnel
   apt:
-    name: stunnel4
+    package: stunnel4
 
 - name: Generate the stunnel private key
   command: openssl genrsa -out {{ stunnel_key }} {{ stunnel_key_size }}

--- a/playbooks/roles/test-client/tasks/shadowsocks.yml
+++ b/playbooks/roles/test-client/tasks/shadowsocks.yml
@@ -41,7 +41,7 @@
 
 - name: "Install zbar-tools"
   apt:
-    name: zbar-tools
+    package: zbar-tools
     force: yes
 
 - name: "Copy Shadowsocks QR code parser tool to client machine"

--- a/playbooks/roles/test-client/tasks/stunnel.yml
+++ b/playbooks/roles/test-client/tasks/stunnel.yml
@@ -5,10 +5,9 @@
 
 - name: "Install stunnel and openvpn"
   apt:
-    name: "{{ item }}"
-  with_items:
-    - "stunnel"
-    - "openvpn"
+    package:
+      - "stunnel"
+      - "openvpn"
 
 - name: "Ensure the stunnel service is stopped and disabled"
   # We need to stop the stunnel service & disable it. By default the Ubuntu 16.04

--- a/playbooks/roles/test-client/tasks/tor.yml
+++ b/playbooks/roles/test-client/tasks/tor.yml
@@ -2,10 +2,9 @@
 
 - name: "Install tor and obs4proxy"
   apt:
-    name: "{{ item }}"
-  with_items:
-    - "tor"
-    - "obfs4proxy"
+    package:
+      - "tor"
+      - "obfs4proxy"
 
 - name: "Remove stale test state if required"
   file:

--- a/playbooks/roles/tinyproxy/tasks/main.yml
+++ b/playbooks/roles/tinyproxy/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Tinyproxy
   apt:
-    name: tinyproxy
+    package: tinyproxy
 
 - name: Stop (init.d's) tinyproxy
   systemd:

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -16,14 +16,13 @@
 
 - name: Install the package to keep the Tor signing key current
   apt:
-    name: deb.torproject.org-keyring
+    package: deb.torproject.org-keyring
 
 - name: Install obfs4 and Tor
   apt:
-    name: "{{ item }}"
-  with_items:
-    - obfs4proxy
-    - tor
+    package:
+      - obfs4proxy
+      - tor
 
 # Update the firewall to allow Tor and obfs4proxy
 # NOTE(@cpu): we do this early in the role because the Tor daemon will check if

--- a/playbooks/roles/ufw/tasks/main.yml
+++ b/playbooks/roles/ufw/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install UFW
   apt:
-    name: ufw
+    package: ufw
 
 - name: Disable UFW logging
   lineinfile:

--- a/playbooks/roles/wireguard/tasks/install.yml
+++ b/playbooks/roles/wireguard/tasks/install.yml
@@ -14,9 +14,8 @@
 
 - name: Install the WireGuard packages
   apt:
-    name: "{{ item }}"
-  with_items:
-    - linux-headers-{{ kernel_release.stdout }}
-    - linux-headers-generic
-    - wireguard-dkms
-    - wireguard-tools
+    package:
+      - linux-headers-{{ kernel_release.stdout }}
+      - linux-headers-generic
+      - wireguard-dkms
+      - wireguard-tools

--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -46,12 +46,12 @@
 
     - name: "Remove old LXD from distro"
       apt:
-        name: "lxd"
+        package: "lxd"
         state: "absent"
 
     - name: "Install snapd"
       apt:
-        name: "snapd"
+        package: "snapd"
 
     - name: "Install LXD snap"
       command: "snap install lxd"

--- a/tests/run.yml
+++ b/tests/run.yml
@@ -30,7 +30,7 @@
 
     - name: Ensure openssh is installed
       apt:
-        name: openssh-server
+        package: openssh-server
 
     - name: Add authorized key
       authorized_key:


### PR DESCRIPTION
I've unilaterally decided that `apt:` stanzas shall consistently use `package:` rather than `name:`.

https://docs.ansible.com/ansible/2.5/modules/apt_module.html#apt-module says that "When used with a loop: each package will be processed individually" and suggests directly feeding a list to `apt:`.