### PR TITLE
Do not delete stunnel's init.d service

### DIFF
--- a/playbooks/roles/stunnel/tasks/main.yml
+++ b/playbooks/roles/stunnel/tasks/main.yml
@@ -40,6 +40,7 @@
   systemd:
     name: stunnel4.service
     state: stopped
+    enabled: no
 
 - name: Copy the stunnel system unit file
   template:

--- a/playbooks/roles/stunnel/tasks/main.yml
+++ b/playbooks/roles/stunnel/tasks/main.yml
@@ -41,11 +41,6 @@
     name: stunnel4.service
     state: stopped
 
-- name: Remove the stunnel init.d script
-  file:
-    state: absent
-    path: "/etc/init.d/stunnel4"
-
 - name: Copy the stunnel system unit file
   template:
     src: stunnel.service.j2

--- a/playbooks/roles/stunnel/tasks/main.yml
+++ b/playbooks/roles/stunnel/tasks/main.yml
@@ -40,7 +40,7 @@
   systemd:
     name: stunnel4.service
     state: stopped
-    enabled: no
+    masked: yes
 
 - name: Copy the stunnel system unit file
   template:


### PR DESCRIPTION
Doing so will fail in re-running the the script on an already spun up server.

Resolves #1454 