### PR TITLE
Updated documentation to fix issue found in Issue #1434

### DIFF
--- a/playbooks/roles/wireguard/templates/instructions.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions.md.j2
@@ -42,6 +42,10 @@ An [experimental configuration for OpenWrt/LEDE](#openwrt) 17.01.4 (or later) is
 
    `sudo sh -c 'umask 077; mkdir -p /etc/wireguard; cat > /etc/wireguard/{{ vpn_client_names.results[0].stdout }}.conf' < ~/Downloads/{{ vpn_client_names.results[0].stdout }}.conf`
 
+1. (Ubuntu/Debian) For Ubuntu and Debian users you will need to install the `openresolv` package:
+
+   `sudo apt-get install openresolv`
+
 1. Use the `wg-quick` utility to bring up the WireGuard interface:
 
    `sudo wg-quick up {{ vpn_client_names.results[0].stdout }}`


### PR DESCRIPTION
This PR was made in response to Issue #1434 . Ubuntu/Debian users will need to use the openresolv package in order to run Wireguard as noted [here](https://lists.zx2c4.com/pipermail/wireguard/2017-May/001351.html) and [here](https://mullvad.net/en/guides/wireguard-and-mullvad-vpn/).

The fix is simple for the user, just install openresolv and Wireguard will be able to use it.

(Had to resubmit this PR due to the GitHub outage issues)