### PR TITLE
Add new Azure regions and update azure_instance_type to newer generation

### DIFF
--- a/playbooks/azure.yml
+++ b/playbooks/azure.yml
@@ -35,12 +35,16 @@
       "26": "southindia"
       "27": "australiaeast"
       "28": "australiasoutheast"
-      "29": "northeurope"
-      "30": "westeurope"
-      "31": "germanycentral"
-      "32": "germanynortheast"
-      "33": "ukwest"
-      "34": "uksouth"
+      "29": "australiacentral"
+      "30": "australiacentral2"
+      "31": "northeurope"
+      "32": "westeurope"
+      "33": "germanycentral"
+      "34": "germanynortheast"
+      "35": "ukwest"
+      "36": "uksouth"
+      "37": "francecentral"
+      "38": "francesouth"
 
   # These variable files are included so the azure-security-group role
   # knows which ports to open
@@ -94,15 +98,20 @@
 
           Australia:
             27: Australia East      (New South Wales)
-            28: Australia Southeast (Victoria)
+            28: Australia Southeast     (Victoria)
+            29: Austrailia Central       (Canberra)
+            30: Austrailia Central 2    (Canberra)
 
           Europe:
-            29: North Europe        (Ireland)
-            30: West Europe         (Netherlands)
-            31: Germany Central     (Frankfurt)
-            32: Germany Northeast   (Magdeburg)
-            33: UK West             (Cardiff)
-            34: UK South            (London)
+            31: North Europe        (Ireland)
+            32: West Europe         (Netherlands)
+            33: Germany Central     (Frankfurt)
+            34: Germany Northeast   (Magdeburg)
+            35: UK West             (Cardiff)
+            36: UK South            (London)
+            37: France Central    (Paris)
+            38: France South      (Marseille)
+
         Please choose the number of your region: Press enter for default (#1) region.
       default: "1"
       private: no

--- a/playbooks/azure.yml
+++ b/playbooks/azure.yml
@@ -35,16 +35,12 @@
       "26": "southindia"
       "27": "australiaeast"
       "28": "australiasoutheast"
-      "29": "australiacentral"
-      "30": "australiacentral2"
-      "31": "northeurope"
-      "32": "westeurope"
-      "33": "germanycentral"
-      "34": "germanynortheast"
-      "35": "ukwest"
-      "36": "uksouth"
-      "37": "francecentral"
-      "38": "francesouth"
+      "29": "northeurope"
+      "30": "westeurope"
+      "31": "germanycentral"
+      "32": "germanynortheast"
+      "33": "ukwest"
+      "34": "uksouth"
 
   # These variable files are included so the azure-security-group role
   # knows which ports to open
@@ -97,21 +93,16 @@
             26: South India         (Chennai)
 
           Australia:
-            27: Australia East              (New South Wales)
-            28: Australia Southeast     (Victoria)
-            29: Austrailia Central       (Canberra)
-            30: Austrailia Central 2    (Canberra)
+            27: Australia East      (New South Wales)
+            28: Australia Southeast (Victoria)
 
           Europe:
-            31: North Europe        (Ireland)
-            32: West Europe         (Netherlands)
-            33: Germany Central     (Frankfurt)
-            34: Germany Northeast   (Magdeburg)
-            35: UK West             (Cardiff)
-            36: UK South            (London)
-            37: France Central    (Paris)
-            38: France South      (Marseille)
-
+            29: North Europe        (Ireland)
+            30: West Europe         (Netherlands)
+            31: Germany Central     (Frankfurt)
+            32: Germany Northeast   (Magdeburg)
+            33: UK West             (Cardiff)
+            34: UK South            (London)
         Please choose the number of your region: Press enter for default (#1) region.
       default: "1"
       private: no

--- a/playbooks/azure.yml
+++ b/playbooks/azure.yml
@@ -35,12 +35,16 @@
       "26": "southindia"
       "27": "australiaeast"
       "28": "australiasoutheast"
-      "29": "northeurope"
-      "30": "westeurope"
-      "31": "germanycentral"
-      "32": "germanynortheast"
-      "33": "ukwest"
-      "34": "uksouth"
+      "29": "australiacentral"
+      "30": "australiacentral2"
+      "31": "northeurope"
+      "32": "westeurope"
+      "33": "germanycentral"
+      "34": "germanynortheast"
+      "35": "ukwest"
+      "36": "uksouth"
+      "37": "francecentral"
+      "38": "francesouth"
 
   # These variable files are included so the azure-security-group role
   # knows which ports to open
@@ -93,16 +97,21 @@
             26: South India         (Chennai)
 
           Australia:
-            27: Australia East      (New South Wales)
-            28: Australia Southeast (Victoria)
+            27: Australia East              (New South Wales)
+            28: Australia Southeast     (Victoria)
+            29: Austrailia Central       (Canberra)
+            30: Austrailia Central 2    (Canberra)
 
           Europe:
-            29: North Europe        (Ireland)
-            30: West Europe         (Netherlands)
-            31: Germany Central     (Frankfurt)
-            32: Germany Northeast   (Magdeburg)
-            33: UK West             (Cardiff)
-            34: UK South            (London)
+            31: North Europe        (Ireland)
+            32: West Europe         (Netherlands)
+            33: Germany Central     (Frankfurt)
+            34: Germany Northeast   (Magdeburg)
+            35: UK West             (Cardiff)
+            36: UK South            (London)
+            37: France Central    (Paris)
+            38: France South      (Marseille)
+
         Please choose the number of your region: Press enter for default (#1) region.
       default: "1"
       private: no

--- a/playbooks/roles/genesis-azure/defaults/main.yml
+++ b/playbooks/roles/genesis-azure/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-azure_instance_type: "Basic_A0"
+azure_instance_type: "Standard_B1s"
 
 azure_image_publisher: "Canonical"
 azure_image_offer:     "UbuntuServer"


### PR DESCRIPTION
Noticed France along with the new Austrailia regions were missing. Added those. 

Additionally, Microsoft is working to deprecate the Basic_A0 VM type (they currently oversubscribe those), and it's currently $14 USD globally as opposed to the newer Standard_B1s, which has more CPU and RAM headroom for less (~$7 USD depending on region).