### PR TITLE
 Fix typo: certifcate -> certificate

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -111,7 +111,7 @@ Effectuez toutes ces tâches sur votre machine locale.
             sudo apt-get install git
   * Sur Fedora 27, certains progiciels sont nécessaires plus tard
 
-          sudo yum install git python2-pip gcc python2-devel python2-crypto python2-pycurl libcurl-devel
+          sudo dnf install git python2-pip gcc python2-devel python2-crypto python2-pycurl libcurl-devel
   * Sur CentOS 7, `pip` est disponible dans le dépôt EPEL; certains progiciels supplémentaires sont nécessaires plus tard.
 
           sudo yum -y update && sudo yum install -y epel-release

--- a/README-ru.md
+++ b/README-ru.md
@@ -110,7 +110,7 @@
         sudo apt-get install git
   * На Fedora
 
-        sudo yum install git
+        sudo dnf install git
   * На macOS (с использованием [Homebrew](https://brew.sh/))
 
         brew install git
@@ -120,7 +120,7 @@
         sudo apt-get install python-paramiko python-pip python-pycurl python-dev build-essential
   * На Fedora
 
-        sudo yum install python-pip
+        sudo dnf install python-pip
   * На macOS
 
         sudo easy_install pip

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Complete all of these tasks on your local home machine.
         sudo apt-get install git python-pip
   * On Fedora 27, some additional packages are needed later.
 
-		sudo yum install git python2-pip gcc python2-devel python2-crypto python2-pycurl libcurl-devel
+		sudo dnf install git python2-pip gcc python2-devel python2-crypto python2-pycurl libcurl-devel
   * On CentOS 7, `pip` is available from the EPEL repository; some additional packages are needed later.
 
 		sudo yum -y update && sudo yum install -y epel-release

--- a/playbooks/roles/openconnect/templates/instructions.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions.md.j2
@@ -23,7 +23,7 @@ Client certificates are a mechanism by which clients can authenticate themselves
 
 1. Your OpenConnect server issues its own __server certificate__. This is used by your device's client software (such as AnyConnect for iOS) to securely identify the VPN server. Download this server's certificate.
    * [ca.crt](/openconnect/ca.crt)
-1. Each device you wish to configure needs a __client certificate__ in addition to the server certificate above. A client certificate is used to securely identify and authenticate your device to the VPN server. Two devices can't use the same client certifcate and be logged in at the same time (one client certificate per device). Each client certificate is protected by a password, which will be needed to unlock it once you import it into your device.
+1. Each device you wish to configure needs a __client certificate__ in addition to the server certificate above. A client certificate is used to securely identify and authenticate your device to the VPN server. Two devices can't use the same client certificate and be logged in at the same time (one client certificate per device). Each client certificate is protected by a password, which will be needed to unlock it once you import it into your device.
 {% for client in vpn_client_pkcs12_password_list.results %}
    * [{{ client.client_name.stdout }}.p12](/openconnect/{{ client.client_name.stdout }}.p12), password: `{{ client.stdout }}` 
 {% endfor %}


### PR DESCRIPTION
Also yum -> dnf for Fedora instructions (yum is gone in Fedora for a while now)