### PR TITLE
Updated the 'python-software-properties' package to 'software-properties-common'.

### DIFF
--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -24,7 +24,7 @@ streisand_common_packages:
   # Required to use the Ansible `expect` module
   - python-pexpect
   # Required for the apt_repository module
-  - python-software-properties
+  - python-properties-common
   # Used to generate convenient QR codes for mobile clients in the
   # Shadowsocks, Tor, and WireGuard roles
   - qrencode

--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -24,7 +24,7 @@ streisand_common_packages:
   # Required to use the Ansible `expect` module
   - python-pexpect
   # Required for the apt_repository module
-  - python-properties-common
+  - software-properties-common
   # Used to generate convenient QR codes for mobile clients in the
   # Shadowsocks, Tor, and WireGuard roles
   - qrencode


### PR DESCRIPTION
While I was working on getting Streisand to run inside a Docker container, I noticed that this package was out of date (and thus causing Streisand to error out). I have updated it and re-tested it. (My first commit I got the name of the package wrong. It was fixed in the second, and then tested).

This is the error I was getting from Streisand:
<img src="https://frichetten.com/images/fail.png"/>

This is what happens when you try to install the outdated package with apt. It recommends the newer one.
<img src="https://frichetten.com/images/package.png"/>

Here is a [link](https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/439566) to another source recommending the newer package.