### PR TITLE
Fix Travis CI builds "public key is not available"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install python-pip python-dev ca-certificates shellcheck -qq
+  # workaround for https://travis-ci.community/t/then-sudo-apt-get-update-failed-public-key-is-not-available-no-pubkey-6b05f25d762e3157-in-ubuntu-xenial/1728
+  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157
 
 install:
   - pip install ansible==2.6.5


### PR DESCRIPTION
Workaround for  [no public key available](https://travis-ci.community/t/then-sudo-apt-get-update-failed-public-key-is-not-available-no-pubkey-6b05f25d762e3157-in-ubuntu-xenial/1728) travis CI errors

![image](https://user-images.githubusercontent.com/920624/51158066-b71b9800-1850-11e9-8526-f97d84ee5b1b.png)
