### PR TITLE
Add a simple /healthz path to the frontend without basic auth enforced.  This can be used for remotely monitoring the uptime of a Streisand box.

### DIFF
--- a/playbooks/roles/streisand-gateway/templates/vhost.j2
+++ b/playbooks/roles/streisand-gateway/templates/vhost.j2
@@ -48,4 +48,11 @@ server {
     autoindex off; 
   }
 
+  # Simple healthcheck path with no auth
+  location /healthz {
+    auth_basic off;
+    default_type text/plain;
+    return 200 "ok";
+  }
+
 }


### PR DESCRIPTION
This adds a simple, unauthenticated `/healthz` path which can be used to monitor the availability of a Streisand box using a service like [uptime robot](https://uptimerobot.com/).  It returns a HTTP `200` message with body `ok`.  The body is intentionally nondescript so as not to expose the fact that the host runs Streisand to unauthenticated visitors.
