### PR TITLE
fix tor install

### DIFF
--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: "Add the Tor APT key"
   apt_key:
-    id: A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
-    keyserver: keyserver.ubuntu.com
+    url: "https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc"
+    state: present
 
 - name: Add the Tor repository
   apt_repository:

--- a/playbooks/roles/tor-bridge/tasks/mirror-common.yml
+++ b/playbooks/roles/tor-bridge/tasks/mirror-common.yml
@@ -14,7 +14,7 @@
   # formats though.
   #
   # https://trac.torproject.org/projects/tor/ticket/8940#comment:28
-  shell: curl -s 'https://www.torproject.org/projects/torbrowser/RecommendedTBBVersions' | python -c 'import json; import re; import sys; j = json.load(sys.stdin); print [re.sub(r"-.*$", "", tbb) for tbb in j if "a" not in tbb and "b" not in tbb][-1];'
+  shell: curl -s 'https://www.torproject.org/projects/torbrowser/RecommendedTBBVersions/' | python -c 'import json; import re; import sys; j = json.load(sys.stdin); print [re.sub(r"-.*$", "", tbb) for tbb in j if "a" not in tbb and "b" not in tbb][-1];'
   args:
     warn: no
   register: tor_latest_recommended_check


### PR DESCRIPTION
This PR changes the apt_key mechanism to pull the GPG key from deb.torproject.org and also fixes the URL used to retrieve TBB version info.