### PR TITLE
Wireguard: prevent ipv6 leaks on clients

### DIFF
--- a/playbooks/roles/wireguard/templates/client.conf.j2
+++ b/playbooks/roles/wireguard/templates/client.conf.j2
@@ -13,5 +13,5 @@ PrivateKey = {{ item[1].stdout }}
 
 [Peer]
 PublicKey = {{ wireguard_server_public_key }}
-AllowedIPs = 0.0.0.0/0
+AllowedIPs = 0.0.0.0/0,::/0
 Endpoint = {{ streisand_ipv4_address }}:{{ wireguard_port }}


### PR DESCRIPTION
Adding "::/0" to AllowedIPs on clients to route all IPv6 traffic through the Wireguard tunnel in addition to IPv4 traffic