### PR TITLE
Use random ports for Tor ORPort and obfs4 port

### DIFF
--- a/playbooks/roles/tor-bridge/defaults/main.yml
+++ b/playbooks/roles/tor-bridge/defaults/main.yml
@@ -1,6 +1,34 @@
 ---
-tor_orport: 8443
-tor_obfs4_port: 9443
+tor_internal_hidden_service_port: 8181
+# Randomize Tor's ORPort and obfs4 port to avoid being
+# easily fingerprinted as a Tor bridge (or a Streisand Tor bridge)
+# See https://lists.torproject.org/pipermail/tor-dev/2014-December/007957.html
+# and https://github.com/StreisandEffect/streisand/issues/101
+# for discussion/more data on the topic.
+# Keep track of ports already being used by other services to avoid port conflicts
+# "map" call is needed here because some of these vars are strings, others are integers
+tor_unavailable_ports: "{{ [
+  nginx_port,
+  ssh_port,
+  le_port,
+  shadowsocks_server_port,
+  wireguard_port,
+  ocserv_port,
+  openvpn_port,
+  stunnel_remote_port,
+  cloudflared_port,
+  tor_internal_hidden_service_port
+] | map('int') | list }}"
+# Choose a random port between 1024-32768--below 1024 would require elevated privileges,
+# and any port above 32768 will be used as "Ephemeral Ports" by anything listening locally
+# (see output of "cat /proc/sys/net/ipv4/ip_local_port_range" for the full range)
+tor_random_port_range: "{{ range(1024, 32768) | list }}"
+# Avoid the common ORPort and obfs4 ports
+tor_common_ports: [9001, 8443, 9443]
+
+# Calculate available ports by excluding common/used ports from our choices for randomization
+tor_available_ports: "{{ tor_random_port_range | difference(tor_common_ports + tor_unavailable_ports) }}"
+
 
 # By default Streisand does *not* publish the Tor relay's service descriptor to
 # the tor network. Using a value of 0 ensures the relay is private to the

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -22,6 +22,15 @@
       - obfs4proxy
       - tor
 
+- name: "Randomize Tor's ORPort"
+  set_fact:
+    tor_orport: "{{ tor_available_ports | random }}"
+
+- name: "Randomize Tor's obfs4 port"
+  set_fact:
+    # The "reject" statement is to avoid using the same random port just chosen for tor_orport
+    tor_obfs4_port: "{{ tor_available_ports | reject('equalto', 'tor_orport') | list | random }}"
+
 # Update the firewall to allow Tor and obfs4proxy
 # NOTE(@cpu): we do this early in the role because the Tor daemon will check if
 # the obfs4proxy port is externally accessible during startup and we want to

--- a/playbooks/roles/tor-bridge/vars/main.yml
+++ b/playbooks/roles/tor-bridge/vars/main.yml
@@ -18,4 +18,4 @@ tor_html_instructions: "{{ tor_gateway_location }}/index.html"
 
 tor_obfs4_qr_code: "{{ tor_gateway_location }}/tor-obfs4-qr-code.png"
 
-tor_internal_hidden_service_address: "127.0.0.1:8181"
+tor_internal_hidden_service_address: "127.0.0.1:{{ tor_internal_hidden_service_port }}"


### PR DESCRIPTION
This is my attempt to address the issue raised in #101 to mitigate Streisand Tor bridges being discoverable by Internet-wide scans on ports 9443/8443 by randomizing Tor's listening ports. The original issue and dev post to the mailing list mostly talks about port 9001 which is apparently the most commonly used ORPort (Tor recommends changing it in their [obfs4 setup guide](https://trac.torproject.org/projects/tor/wiki/doc/PluggableTransports/obfs4proxy)). These days whenever I see public Tor bridges I'm usually seeing 9443, 8443, or 443 in many cases too. I wrote these changes to avoid using any of those ports (it chooses a random port between 1024-32768, while excluding commonly used ports and Streisand's services ports) and hopefully discourage at least some percentage of Internet-wide scans checking for Tor bridges on those ports. Though I'd imagine a scan/fingerprinting is still feasible, it'd be at least somewhat more cost-prohibitive since you'd have a much larger list of ports to probe, especially if you're only targeting "Tor" bridges and not "A-Streisand-Server-possibly-running-Tor".

Thinking about something like this more longterm though, I thought about maybe making changes to (optionally?) randomize all of Streisand's ports (SSH, VPNs/tunnels, etc.) to try and reduce the overall "Streisand" fingerprint even more, and perhaps make that a prompt/option for users. I don't know if such an option would be desired but I'm more than happy to take a stab at it if anyone has any thoughts around that!