### PR TITLE
CI fix: define v2ray as a randomizable option

### DIFF
--- a/tests/site_vars/random.yml
+++ b/tests/site_vars/random.yml
@@ -5,6 +5,7 @@ vpn_clients: 1
 streisand_openconnect_enabled: no
 streisand_openvpn_enabled: no
 streisand_shadowsocks_enabled: no
+streisand_shadowsocks_v2ray_enabled: no
 streisand_stunnel_enabled: no
 streisand_tinyproxy_enabled: no
 streisand_tor_enabled: no


### PR DESCRIPTION
CI "random" was blowing up when shadowsocks got selected, because the variable `streisand_shadowsocks_v2ray_enabled` was undefined. Include it as one of the randomized options.