### PR TITLE
Bump Ansible to 2.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157
 
 install:
-  - pip install ansible==2.8.0
+  - pip install ansible==2.8.3
   - pip install urllib3 yamllint
   - ansible --version
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 
 # Core with Azure dependencies
 #
-ansible[azure]==2.8.0
+ansible[azure]==2.8.3
 
 # Multiple packages depend on SecretStorage, and versions >= 3 require
 # Python 3. Until we're ready for Python 3, specify the earlier rev.
@@ -21,7 +21,7 @@ boto
 boto3
 
 # Digital Ocean
-dopy==0.3.5
+dopy
 
 # Google Compute Engine
 requests

--- a/util/ansible_check.sh
+++ b/util/ansible_check.sh
@@ -6,7 +6,7 @@ set -e
 # check_ansible checks that Ansible is installed on the local system
 # and that it is a supported version.
 function check_ansible() {
-  local REQUIRED_ANSIBLE_VERSION="2.8.0"
+  local REQUIRED_ANSIBLE_VERSION="2.8.3"
 
   if ! command -v ansible > /dev/null 2>&1; then
     echo "


### PR DESCRIPTION
Avoids CVE-2019-10156.
https://nvd.nist.gov/vuln/detail/CVE-2019-10156

I unpinned `dopy`. Tested against DigitalOcean.