### PR TITLE
Fix libcloud requirement error on GCP builds (#1623)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ dopy==0.3.5
 # Google Compute Engine
 requests
 google-auth
+apache-libcloud
 
 # Linode
 linode-api4


### PR DESCRIPTION
This should fix the error seen when creating a new network in GCP (inside the `gce-network: Create network` task) when running Streisand for the first time. Error message below (originally reported in #1623):

> TASK [gce-network : Create network] ********************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "libcloud with GCE support (0.17.0+) required for this module"}

Apparently `apache-libcloud` is a requirement for the `gce_net` module in Ansible, which is being used inside this playbook:

https://github.com/StreisandEffect/streisand/blob/master/playbooks/roles/gce-network/tasks/main.yml#L3

The error message seems to come from this file within Ansible:

https://github.com/ansible/ansible/blob/v2.8.0/lib/ansible/modules/cloud/google/gce_net.py#L301

This file does a check to see if the python module `libcloud` can be imported (see [this line](https://github.com/ansible/ansible/blob/v2.8.0/lib/ansible/modules/cloud/google/gce_net.py#L226)), and fails with that error message above if it's unable to find `libcloud`. It's also listed on the requirements page in the Ansible doc for `gce_net`, so it seems safe to assume this should be a requirement:

https://docs.ansible.com/ansible/latest/modules/gce_net_module.html#requirements
  