### PR TITLE
Upgrade digitalocean module

### DIFF
--- a/README-chs.md
+++ b/README-chs.md
@@ -133,9 +133,6 @@ Streisand 运行在**你自己的计算机上时（或者你电脑的虚拟机�
   * 微软云服务
 
         sudo pip install ansible[azure]
-  * DigitalOcean
-
-        sudo pip install dopy==0.3.5
   * Google
 
         sudo pip install "apache-libcloud>=1.17.0"

--- a/README-ru.md
+++ b/README-ru.md
@@ -140,9 +140,6 @@
   * Azure
 
         sudo pip install ansible[azure]
-  * DigitalOcean
-
-        sudo pip install dopy==0.3.5
   * Google
 
         sudo pip install "apache-libcloud>=1.17.0"

--- a/playbooks/roles/genesis-digitalocean/tasks/main.yml
+++ b/playbooks/roles/genesis-digitalocean/tasks/main.yml
@@ -13,28 +13,28 @@
 
 - block:
     - name: Add the SSH key to DigitalOcean if it doesn't already exist
-      digital_ocean:
-        command: ssh
+      digital_ocean_sshkey:
         name: "{{ do_ssh_name }}"
         ssh_pub_key: "{{ ssh_key.stdout }}"
-        api_token: "{{ do_access_token }}"
+        oauth_token: "{{ do_access_token }}"
+        state: present
       register: do_ssh_key
   rescue:
     - fail:
-        msg: "* The API Access Token might be incorrect or missing the Write Scope. OR * The SSH key may already exist in the DigitalOcean Control Panel under a different name. OR * The dopy Python module might not be installed. Use `pip install dopy==0.3.5` to install this module. On the latest version of macOS, dopy > 0.3.5 is currently broken."
+        msg: "* The API Access Token might be incorrect or missing the Write Scope. OR * The SSH key may already exist in the DigitalOcean Control Panel under a different name."
 
 - block:
     - name: Create the new Droplet
-      digital_ocean:
-        command: droplet
+      digital_ocean_droplet:
         name: "{{ do_server_name }}"
-        ssh_key_ids: "{{ do_ssh_key.ssh_key.id }}"
-        size_id: "{{ do_small_droplet_size_id }}"
-        region_id: "{{ regions[do_region] }}"
-        image_id: "{{ do_ubuntu_x64_image_id }}"
+        ssh_keys: "{{ do_ssh_key.data.ssh_key.id }}"
+        size: "{{ do_small_droplet_size_id }}"
+        region: "{{ regions[do_region] }}"
+        image: "{{ do_ubuntu_x64_image_id }}"
         unique_name: yes
         wait: yes
-        api_token: "{{ do_access_token }}"
+        oauth_token: "{{ do_access_token }}"
+        state: present
       register: streisand_server
   rescue:
     - fail:
@@ -42,19 +42,19 @@
 
 - name: Wait until the server has finished booting and OpenSSH is accepting connections
   wait_for:
-    host: "{{ streisand_server.droplet.ip_address }}"
+    host: "{{ streisand_server.data.ip_address }}"
     port: 22
     search_regex: OpenSSH
     timeout: 600
 
 - name: Create the in-memory inventory group
   add_host:
-    name: "{{ streisand_server.droplet.ip_address }}"
+    name: "{{ streisand_server.data.ip_address }}"
     groups: streisand-host
 
 - name: Set the streisand_ipv4_address variable
   set_fact:
-    streisand_ipv4_address: "{{ streisand_server.droplet.ip_address }}"
+    streisand_ipv4_address: "{{ streisand_server.data.ip_address }}"
 
 - name: Set the streisand_server_name variable
   set_fact:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,6 @@ SecretStorage<3.0
 boto
 boto3
 
-# Digital Ocean
-dopy==0.3.5
-
 # Google Compute Engine
 requests
 google-auth


### PR DESCRIPTION
PR to upgrade the `digital_ocean` Ansible module to use the newer `digital_ocean_droplet` and `digital_ocean_sshkey` modules.

See deprecation notice here for `digital_ocean` (will be removed in Ansible 2.12):
https://docs.ansible.com/ansible/latest/modules/digital_ocean_module.html#deprecated

Not sure if Streisand will be upgrading to Ansible 2.12 anytime soon, but I figured it couldn't hurt since it was a pretty easy upgrade (the syntax is very similar). It has the added benefit of removing an external dependency on the python module `dopy` (not that I have anything against it :). Tested against digitalocean and seems to work well without `dopy` installed into the virtualenv.