### PR TITLE
Fix AWS assign_public_ip crash

### DIFF
--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -35,10 +35,6 @@
       name: "{{ aws_ami_name }}"
   register: ami
 
-- name: debug
-  debug:
-    msg: "and {{ aws_vpc_subnet_id is defined and aws_vpc_subnet_id != '' }}"
-
 - name: Create the EC2 instance
   ec2:
     aws_access_key: "{{ aws_access_key }}"

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -85,7 +85,6 @@
     aws_secret_key: "{{ aws_secret_key }}"
     region: "{{ aws_region }}"
     device_id: "{{ streisand_server.instances[0].id }}"
-    private_ip_address: "{{ streisand_server.instances[0].private_ip }}"
     in_vpc: "{{ aws_vpc_id is defined and aws_vpc_id != '' }}"
   register: instance_eip
 

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -35,6 +35,10 @@
       name: "{{ aws_ami_name }}"
   register: ami
 
+- name: debug
+  debug:
+    msg: "and {{ aws_vpc_subnet_id is defined and aws_vpc_subnet_id != '' }}"
+
 - name: Create the EC2 instance
   ec2:
     aws_access_key: "{{ aws_access_key }}"
@@ -43,7 +47,7 @@
     image: "{{ ami.images|sort(reverse=True,attribute='name')|map(attribute='image_id')|first }}"
     region: "{{ aws_region }}"
     vpc_subnet_id: "{{ aws_vpc_subnet_id | default(omit) }}"
-    assign_public_ip: "{{ aws_vpc_subnet_id is defined and aws_vpc_subnet_id != '' }}"
+    assign_public_ip: "{{ (aws_vpc_subnet_id is defined and aws_vpc_subnet_id != '') or omit }}"
     key_name: streisand-ssh
     group: "{{ aws_security_group }}"
     instance_tags:

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -85,6 +85,7 @@
     aws_secret_key: "{{ aws_secret_key }}"
     region: "{{ aws_region }}"
     device_id: "{{ streisand_server.instances[0].id }}"
+    private_ip_address: "{{ streisand_server.instances[0].private_ip }}"
     in_vpc: "{{ aws_vpc_id is defined and aws_vpc_id != '' }}"
   register: instance_eip
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 
 # Core with Azure dependencies
 #
-ansible[azure]==2.8.0
+ansible[azure]==2.8.3
 
 # Multiple packages depend on SecretStorage, and versions >= 3 require
 # Python 3. Until we're ready for Python 3, specify the earlier rev.


### PR DESCRIPTION
If the user has specified a VPC to launch into, we can clearly use `assign_public_ip: true`. But if the VPC is undefined, we shouldn't specify this. And apparently `assign_public_ip: false` is not good enough; we need to *omit* the clause.

Fixes #1509. Fixes #1499.