### PR TITLE
[Temporary] workaround for v2ray/core insecure redirect issue

### DIFF
--- a/playbooks/customize.yml
+++ b/playbooks/customize.yml
@@ -33,7 +33,7 @@
       default: "yes"
       private: no
     - name: streisand_shadowsocks_v2ray_enabled
-      prompt: "Enable v2ray-plugin for Shadowsocks (currently broken)? Press enter for default "
+      prompt: "Enable v2ray-plugin for Shadowsocks? Press enter for default "
       default: "no"
       private: no
     - name: streisand_ssh_forward_enabled

--- a/playbooks/roles/shadowsocks/tasks/v2ray.yml
+++ b/playbooks/roles/shadowsocks/tasks/v2ray.yml
@@ -11,24 +11,23 @@
   apt:
     package: "golang-go"
 
-- name: Set GOPATH
-  shell: "export {{ go_path }}"
-
 # Temporary workaround for insecure v2ray.com redirection
 # see https://github.com/StreisandEffect/streisand/issues/1642
 # for more info. We clone the v2ray-core repository to avoid
 # the "go get" command failing with an "insecure redirect" error.
 - file:
-    path: "{{ ansible_env.HOME }}/go/src/v2ray.com"
+    path: "{{ go_path }}/src/v2ray.com"
     state: directory
 
 - name: "[Temporary] Clone v2ray-core repository manually to GOPATH"
   git:
-    repo: "https://github.com/v2ray/v2ray-core"
-    dest: "{{ ansible_env.HOME }}/go/src/v2ray.com/core"
+    repo: "{{ v2ray_core_github }}"
+    dest: "{{ go_path }}/src/v2ray.com/core"
 
 - name: Get V2Ray-plugin
   shell: "go get {{ v2ray_github }}"
+  environment:
+    GOPATH: "{{ go_path }}"
 
 - name: Copying v2ray-plugin to shadowsocks-libev directory
   shell: "cp -rf {{ v2ray_location }}/v2ray-plugin {{ shadowsocks_location }}"

--- a/playbooks/roles/shadowsocks/tasks/v2ray.yml
+++ b/playbooks/roles/shadowsocks/tasks/v2ray.yml
@@ -14,6 +14,19 @@
 - name: Set GOPATH
   shell: "export {{ go_path }}"
 
+# Temporary workaround for insecure v2ray.com redirection
+# see https://github.com/StreisandEffect/streisand/issues/1642
+# for more info. We clone the v2ray-core repository to avoid
+# the "go get" command failing with an "insecure redirect" error.
+- file:
+    path: "{{ ansible_env.HOME }}/go/src/v2ray.com"
+    state: directory
+
+- name: "[Temporary] Clone v2ray-core repository manually to GOPATH"
+  git:
+    repo: "https://github.com/v2ray/v2ray-core"
+    dest: "{{ ansible_env.HOME }}/go/src/v2ray.com/core"
+
 - name: Get V2Ray-plugin
   shell: "go get {{ v2ray_github }}"
 

--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -3,9 +3,10 @@ shadowsocks_location: "/etc/shadowsocks-libev"
 shadowsocks_password_file: "{{ shadowsocks_location }}/shadowsocks-password.txt"
 
 # V2ray-plugin
-go_path: "GOPATH=$HOME/go"
+go_path: "{{ ansible_env.HOME }}/go"
 v2ray_github: "github.com/shadowsocks/v2ray-plugin"
-v2ray_location: "/root/go/bin"
+v2ray_core_github: "https://github.com/v2ray/v2ray-core"
+v2ray_location: "{{ go_path }}/bin"
 v2ray_options: "server;host={{ shadowsocks_v2ray_cover_domain }}"
 
 # Add -v for verbose mode to help with debugging

--- a/tests/site_vars/shadowsocks.yml
+++ b/tests/site_vars/shadowsocks.yml
@@ -6,8 +6,7 @@ streisand_cloudflared_enabled: no
 streisand_openconnect_enabled: no
 streisand_openvpn_enabled: no
 streisand_shadowsocks_enabled: yes
-# This is temporary, until we have a working v2ray patch
-streisand_shadowsocks_v2ray_enabled: no
+streisand_shadowsocks_v2ray_enabled: yes
 streisand_ssh_forward_enabled: no
 streisand_sshuttle_enabled: no
 streisand_stunnel_enabled: no


### PR DESCRIPTION
See https://github.com/StreisandEffect/streisand/issues/1642

Under the hood, `go get` uses git to fetch upstream dependencies, so we just manually clone the v2ray/v2ray-core repo just before running `go get`. When the v2ray role runs the `go get` command, go will see that the v2ray/v2ray-core repo already exists in `GOPATH` and will skip fetching the repository, and no longer fail with the "insecure redirect" error.

This workaround ideally should be removed when either go releases a new version that ignores unsafe redirects, or Github Pages is able to fix the insecure redirect bug that exists for v2ray.com/core (see https://github.com/StreisandEffect/streisand/issues/1642#issuecomment-529265026)

Also, I figured it made sense to revert [073b8a](https://github.com/StreisandEffect/streisand/commit/073b8afae8614c35240bd4384e18182c60a99d77) and enable v2ray in CI again.