### PR TITLE
Adds certbot deploy hook to reload nginx after cert renewal

### DIFF
--- a/playbooks/roles/lets-encrypt/files/01-reload-nginx.sh
+++ b/playbooks/roles/lets-encrypt/files/01-reload-nginx.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Deploy hook that runs after a successful certbot renewal (not each attempt)
+
+# Reload nginx to gracefully shut down old worker processes and serve the new cert.
+systemctl reload nginx

--- a/playbooks/roles/lets-encrypt/tasks/main.yml
+++ b/playbooks/roles/lets-encrypt/tasks/main.yml
@@ -44,6 +44,14 @@
         option: webroot_path
         value: "{{ nginx_default_html_path }}"
 
+    - name: Setup deploy hook to reload nginx after successful auto renewal
+      copy:
+        src: 01-reload-nginx.sh
+        dest: "{{ le_base }}/renewal-hooks/deploy/01-reload-nginx.sh"
+        owner: root
+        group: root
+        mode: 0750
+
     - set_fact:
         le_ok: True
 


### PR DESCRIPTION
In testing the `lets-encrypt` role recently, I forced renewal for an existing cert (`certbot --force-renewal renew`) and realized nginx was still serving the old certificate, even though the renewal technically worked.

This PR fixes that by using a deploy hook (documented [here](https://certbot.eff.org/docs/using.html#renewing-certificates)), which runs after successful certificate renewals (not each attempt).

The deploy hook is simply a script that runs one command: `systemctl reload nginx`. Reloading nginx will cause it to start serving the new certificate, and gracefully shutdown old worker processes.

For posterity's sake, if anyone already deployed the certbot changes in [this PR](https://github.com/StreisandEffect/streisand/pull/1668), you can manually implement this fix if you don't want to destroy and recreate your existing Streisand server:

```
[root@streisand]# cat > /etc/letsencrypt/renewal-hooks/deploy/01-reload-nginx.sh << EOF
#!/bin/sh
systemctl reload nginx
EOF
```
Make sure the file is executable:
`chmod u+x /etc/letsencrypt/renewal-hooks/deploy/01-reload-nginx.sh`

If your certificate was already auto-renewed by certbot, you'll also need to reload nginx manually since the deploy hook wasn't present during renewal:
`systemctl reload nginx`