### PR TITLE
Appended \config to suggested path for the stunnel.conf file (#1692)

### DIFF
--- a/playbooks/roles/openvpn/templates/stunnel-instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/stunnel-instructions.md.j2
@@ -24,7 +24,7 @@ For security reasons, OpenVPN clients typically have their own unique certificat
 1. Download and run the [stunnel installer](/mirror/#stunnel).
 1. Download the `stunnel.conf` file that has been customized to work with this server:
    * [stunnel.conf](/openvpn/stunnel.conf)
-1. Open the directory where you installed stunnel. For most users, this will either be in *C:\Program Files\stunnel* or *C:\Program Files (x86)\stunnel*.
+1. Open the directory where you installed stunnel. For most users, this will either be in *C:\Program Files\stunnel\config* or *C:\Program Files (x86)\stunnel\config*.
 1. Drag and drop the downloaded `stunnel.conf` file into this directory.
 1. Double click *stunnel.exe* in the installation directory to start the service.
 


### PR DESCRIPTION
The Windows Stunnel Setup instructions (https://x.x.x.x/openvpn/stunnel.html#windows) in step 3 say to "Open the directory where you installed stunnel. For most users, this will either be in C:\Program Files\stunnel or C:\Program Files (x86)\stunnel."  I had to append "\config" to that path, e.g. “C:\Program Files (x86)\stunnel\config” to get to the directory where the existing stunnel.conf file was, the one that needed replaced.  This changes the instructions to specify that subdirectory.