### PR TITLE
ec2 to ec2_instances module migration

### DIFF
--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -64,6 +64,7 @@
           16. us-east-2       US East        (Ohio)
           17. us-west-1       US West        (N. California)
           18. us-west-2       US West        (Oregon)
+
         Please choose the number of your region. Press enter for default (#16) region.
       default: "16"
       private: no

--- a/playbooks/roles/genesis-amazon/defaults/main.yml
+++ b/playbooks/roles/genesis-amazon/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-aws_instance_type: "t2.micro"
+aws_instance_type: "t3.micro"
 # Search AMIs owned by this owner. This is the Amazon owner ID.
 aws_ami_owner: "099720109477"
 # Find AMIs matching this name

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -36,17 +36,18 @@
   register: ami
 
 - name: Create the EC2 instance
-  ec2:
+  ec2_instance:
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
     instance_type: "{{ aws_instance_type }}"
-    image: "{{ ami.images|sort(reverse=True,attribute='name')|map(attribute='image_id')|first }}"
+    image_id: "{{ ami.images|sort(reverse=True,attribute='name')|map(attribute='image_id')|first }}"
     region: "{{ aws_region }}"
     vpc_subnet_id: "{{ aws_vpc_subnet_id | default(omit) }}"
-    assign_public_ip: "{{ (aws_vpc_subnet_id is defined and aws_vpc_subnet_id != '') or omit }}"
+    network:
+      assign_public_ip: "{{ (aws_vpc_subnet_id is defined and aws_vpc_subnet_id != '') or omit }}"
     key_name: streisand-ssh
-    group: "{{ aws_security_group }}"
-    instance_tags:
+    security_group: "{{ aws_security_group }}"
+    tags:
       Name: "{{ aws_instance_name }}"
     wait: yes
   register: streisand_server
@@ -67,14 +68,14 @@
     period: 60
     evaluation_periods: 2
     dimensions:
-      InstanceId: "{{ streisand_server.instances[0].id }}"
+      InstanceId: "{{ streisand_server.instances[0].instance_id }}"
     alarm_actions:
       - "arn:aws:automate:{{ aws_region }}:ec2:recover"
-  when: aws_instance_type.startswith(("t2", "c3", "c4", "m3", "m4", "r3", "x1"))
+  when: aws_instance_type.startswith(("t2", "t3", "c3", "c4", "m3", "m4", "r3", "x1"))
 
 - name: Wait until the server has finished booting and OpenSSH is accepting connections
   wait_for:
-    host: "{{ streisand_server.instances[0].public_ip }}"
+    host: "{{ streisand_server.instances[0].public_ip_address }}"
     port: 22
     search_regex: OpenSSH
     timeout: 600
@@ -84,7 +85,7 @@
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
     region: "{{ aws_region }}"
-    device_id: "{{ streisand_server.instances[0].id }}"
+    device_id: "{{ streisand_server.instances[0].instance_id }}"
     in_vpc: "{{ aws_vpc_id is defined and aws_vpc_id != '' }}"
   register: instance_eip
 


### PR DESCRIPTION
in this pull, I'm laying the groundwork to support later Ansible version where the ec2 module will be deprecated in favor of ec2_instances
Currently, there are a few modules that only recently got merged in ansible 2.10 devel that will allow us to move the metric module to support boto3. This will allow us to enable the new zones like me-south-1 that are currently not supported with boto and they don't accept pull requests for it. 