### PR TITLE
Bump up the size of nginx hashes; some people are running into size limits

### DIFF
--- a/playbooks/roles/nginx/files/nginx.conf
+++ b/playbooks/roles/nginx/files/nginx.conf
@@ -13,8 +13,8 @@ http {
     tcp_nopush     on;
     tcp_nodelay    on;
 
-    server_names_hash_bucket_size  64;
-    types_hash_max_size   2048;
+    server_names_hash_bucket_size  128;
+    types_hash_max_size   4096;
     client_max_body_size  10M;
     server_tokens off;
     keepalive_timeout  65;


### PR DESCRIPTION
See #1699 for an example of this.

nginx is not the most performance-critical piece of software in Streisand. 