### PR TITLE
Use a proper Ansible version comparison (because stringwise, 2.8.10<2.8.4)

### DIFF
--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -98,7 +98,7 @@
 
     - name: Install python in container
       delegate_to: streisand
-      raw: apt-get install -y python3 python3-apt python3-pip
+      raw: apt-get update && apt-get install -y python3 python3-apt python3-pip
 
     - name: Set python3 as the default
       raw: update-alternatives --install /usr/bin/python python /usr/bin/python3 1

--- a/util/ansible_check.sh
+++ b/util/ansible_check.sh
@@ -1,7 +1,4 @@
-#!/bin/bash
-
-# Set errexit option to exit immediately on any non-zero status return.
-set -e
+# This is included by the main streisand script.
 
 # check_ansible checks that Ansible is installed on the local system
 # and that it is a supported version.
@@ -15,10 +12,13 @@ Please see the README Installation section on Prerequisites"
     exit 1
   fi
 
-  if [[ $(ansible --version | grep -oe '2\(.[0-9]\)*') < $REQUIRED_ANSIBLE_VERSION ]]; then
+  ansible_version="$(ansible --version | head -1 | grep -oe '2[.0-9]*')"
+
+  if ! ./util/version_at_least.py "$REQUIRED_ANSIBLE_VERSION" "$ansible_version" ; then
       echo "
 Streisand requires Ansible version $REQUIRED_ANSIBLE_VERSION or higher.
-This system has Ansible $(ansible --version)."
+This system has Ansible $ansible_version.
+"
       exit 1
   fi
 }

--- a/util/ansible_check.sh
+++ b/util/ansible_check.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 # This is included by the main streisand script.
 
 # check_ansible checks that Ansible is installed on the local system

--- a/util/version_at_least.py
+++ b/util/version_at_least.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import sys
+from distutils.version import StrictVersion
+
+if len(sys.argv) != 3:
+    print("Usage: version_at_least minimum_version version_to_check")
+    sys.exit(1)
+
+minimum_version = StrictVersion(sys.argv[1].strip())
+version_to_check = StrictVersion(sys.argv[2].strip())
+
+if version_to_check >= minimum_version:
+    sys.exit(0)
+else:
+    sys.exit(1)


### PR DESCRIPTION
CI is blowing up because 2.8.10 of Ansible has been released, and "2.8.10" < "2.8.4". Write a tiny Python utility to do proper version comparisons.