### PR TITLE
Add Cape Town to AWS server list

### DIFF
--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -8,24 +8,26 @@
   vars:
     # The region dict is generated from ./util/print-aws-regions.py
     regions:
-      "1": "ap-east-1"
-      "2": "ap-northeast-1"
-      "3": "ap-northeast-2"
-      "4": "ap-northeast-3"
-      "5": "ap-south-1"
-      "6": "ap-southeast-1"
-      "7": "ap-southeast-2"
-      "8": "ca-central-1"
-      "9": "eu-central-1"
-      "10": "eu-north-1"
-      "11": "eu-west-1"
-      "12": "eu-west-2"
-      "13": "eu-west-3"
-      "14": "sa-east-1"
-      "15": "us-east-1"
-      "16": "us-east-2"
-      "17": "us-west-1"
-      "18": "us-west-2"
+      "1": "af-south-1"
+      "2": "ap-east-1"
+      "3": "ap-northeast-1"
+      "4": "ap-northeast-2"
+      "5": "ap-northeast-3"
+      "6": "ap-south-1"
+      "7": "ap-southeast-1"
+      "8": "ap-southeast-2"
+      "9": "ca-central-1"
+      "10": "eu-central-1"
+      "11": "eu-north-1"
+      "12": "eu-west-1"
+      "13": "eu-west-2"
+      "14": "eu-west-3"
+      "15": "sa-east-1"
+      "16": "us-east-1"
+      "17": "us-east-2"
+      "18": "us-west-1"
+      "19": "us-west-2"
+
 
   # These variable files are included so the ec2-security-group role
   # knows which ports to open
@@ -46,26 +48,27 @@
     - name: "aws_region_var"
       prompt: |
         In what region should the server be located?
-           1. ap-east-1       Asia Pacific   (Hong Kong)
-           2. ap-northeast-1  Asia Pacific   (Tokyo)
-           3. ap-northeast-2  Asia Pacific   (Seoul)
-           4. ap-northeast-3  Asia Pacific   (Osaka-Local)
-           5. ap-south-1      Asia Pacific   (Mumbai)
-           6. ap-southeast-1  Asia Pacific   (Singapore)
-           7. ap-southeast-2  Asia Pacific   (Sydney)
-           8. ca-central-1    Canada         (Central)
-           9. eu-central-1    EU             (Frankfurt)
-          10. eu-north-1      EU             (Stockholm)
-          11. eu-west-1       EU             (Ireland)
-          12. eu-west-2       EU             (London)
-          13. eu-west-3       EU             (Paris)
-          14. sa-east-1       South America  (São Paulo)
-          15. us-east-1       US East        (N. Virginia)
-          16. us-east-2       US East        (Ohio)
-          17. us-west-1       US West        (N. California)
-          18. us-west-2       US West        (Oregon)
-        Please choose the number of your region. Press enter for default (#16) region.
-      default: "16"
+           1. af-south-1c     Africa         (Cape Town)
+           2. ap-east-1       Asia Pacific   (Hong Kong)
+           3. ap-northeast-1  Asia Pacific   (Tokyo)
+           4. ap-northeast-2  Asia Pacific   (Seoul)
+           5. ap-northeast-3  Asia Pacific   (Osaka-Local)
+           6. ap-south-1      Asia Pacific   (Mumbai)
+           7. ap-southeast-1  Asia Pacific   (Singapore)
+           8. ap-southeast-2  Asia Pacific   (Sydney)
+           9. ca-central-1    Canada         (Central)
+          10. eu-central-1    EU             (Frankfurt)
+          11. eu-north-1      EU             (Stockholm)
+          12. eu-west-1       EU             (Ireland)
+          13. eu-west-2       EU             (London)
+          14. eu-west-3       EU             (Paris)
+          15. sa-east-1       South America  (São Paulo)
+          16. us-east-1       US East        (N. Virginia)
+          17. us-east-2       US East        (Ohio)
+          18. us-west-1       US West        (N. California)
+          19. us-west-2       US West        (Oregon)
+        Please choose the number of your region. Press enter for default (#17) region.
+      default: "17"
       private: no
 
     - name: "aws_vpc_id_var"

--- a/util/print-aws-regions.py
+++ b/util/print-aws-regions.py
@@ -13,6 +13,7 @@ names = (
     ("eu-west-1",      "EU",           "Ireland"),
     ("eu-west-2",      "EU",           "London"),
     ("eu-west-3",      "EU",           "Paris"),
+    ("af-south-1",    "Africa",       "Cape Town"),
     ("ap-northeast-1", "Asia Pacific", "Tokyo"),
     ("ap-northeast-2", "Asia Pacific", "Seoul"),
     ("ap-northeast-3", "Asia Pacific", "Osaka-Local"),


### PR DESCRIPTION
Created by adding it to `util/print-aws-regions.py`, running that and copying the output to the amazon playbook.