### PR TITLE
Added region af_south_1 and machine type t3.micro

### DIFF
--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -26,6 +26,7 @@
       "16": "us-east-2"
       "17": "us-west-1"
       "18": "us-west-2"
+      "19": "af-south-1"
 
   # These variable files are included so the ec2-security-group role
   # knows which ports to open
@@ -64,6 +65,7 @@
           16. us-east-2       US East        (Ohio)
           17. us-west-1       US West        (N. California)
           18. us-west-2       US West        (Oregon)
+          19. af-south-1      Africa         (Cape Town)
         Please choose the number of your region. Press enter for default (#16) region.
       default: "16"
       private: no

--- a/playbooks/roles/genesis-amazon/defaults/main.yml
+++ b/playbooks/roles/genesis-amazon/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-aws_instance_type: "t2.micro"
+aws_instance_type: "t3.micro"
 # Search AMIs owned by this owner. This is the Amazon owner ID.
 aws_ami_owner: "099720109477"
 # Find AMIs matching this name

--- a/util/print-aws-regions.py
+++ b/util/print-aws-regions.py
@@ -4,6 +4,7 @@
 # Generate code fragments for amazon.yml
 
 names = (
+    ("af-south-1",     "Africa",       "Cape Town"),
     ("us-east-1",      "US East",      "N. Virginia"),
     ("us-east-2",      "US East",      "Ohio"),
     ("us-west-1",      "US West",      "N. California"),


### PR DESCRIPTION
The regions af-south-1 and the instance type t3.micro wasn't supported. This adds support.